### PR TITLE
PM2 Runtime documentation URL changed

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ This setup has only been tested with Ubuntu 18.04, but should work with other OS
  - [RabbitMQ](https://www.rabbitmq.com/install-debian.html)
  - [Redis](https://redis.io/topics/quickstart)
  - [Node.js v12](https://github.com/nodesource/distributions/blob/master/README.md#installation-instructions)
- - [PM2](https://pm2.io/doc/en/runtime/quick-start)
+ - [PM2](http://pm2.keymetrics.io/docs/usage/quick-start/)
  - Nodeos 1.8.4 w/ state_history_plugin and chain_api_plugin
   
   > The indexer requires redis, pm2 and node.js to be on the same machine. Other dependencies might be installed on other machines, preferably over a very high speed and low latency network. Indexing speed will vary greatly depending on this configuration.


### PR DESCRIPTION
It seems that PM2 Runtime documentation has moved, updating the URL
(no HTTPS available)