### PR TITLE
Fix a path in modules/index.js

### DIFF
--- a/modules/index.js
+++ b/modules/index.js
@@ -44,7 +44,7 @@ class HyperionModuleLoader {
     }
 
     loadActionHandlers() {
-        const files = fs.readdirSync('modules/action_data/');
+        const files = fs.readdirSync(path.join(__dirname, 'action_data'));
         for (const plugin of files) {
             const _module = require(path.join(__dirname, 'action_data', plugin)).hyperionModule;
             if (_module.parser_version.includes(process.env.PARSER)) {


### PR DESCRIPTION
Should use path.join here as well to avoid issues with different work dirs. 