### PR TITLE
Add the total number of indexed blocks to the health API.

### DIFF
--- a/api/routes/v2/health/health.ts
+++ b/api/routes/v2/health/health.ts
@@ -2,7 +2,7 @@ import {FastifyInstance, FastifyReply, FastifyRequest} from "fastify";
 import {ServerResponse} from "http";
 import {connect} from "amqplib";
 import {timedQuery} from "../../../helpers/functions";
-import {getLastIndexedBlock} from "../../../../helpers/common_functions";
+import {getLastIndexedBlockWithTotalBlocks} from "../../../../helpers/common_functions";
 
 async function checkRabbit(fastify: FastifyInstance) {
     try {
@@ -39,9 +39,10 @@ async function checkNodeos(fastify: FastifyInstance) {
 async function checkElastic(fastify: FastifyInstance) {
     try {
         let esStatus = await fastify.elastic.cat.health({format: 'json', v: true});
-        let lastIndexedBlock = await getLastIndexedBlock(fastify.elastic, fastify.manager.chain);
+        let indexedBlocks = await getLastIndexedBlockWithTotalBlocks(fastify.elastic, fastify.manager.chain);
         const data = {
-            last_indexed_block: lastIndexedBlock,
+            last_indexed_block: indexedBlocks[0],
+            total_indexed_blocks: indexedBlocks[1],
             active_shards: esStatus.body[0]['active_shards_percent']
         };
         let stat = 'OK';

--- a/helpers/common_functions.ts
+++ b/helpers/common_functions.ts
@@ -53,6 +53,25 @@ export async function getLastIndexedBlock(es_client: Client, chain: string) {
     return getLastResult(results);
 }
 
+export async function getLastIndexedBlockWithTotalBlocks(es_client: Client, chain: string): Promise<[number, number]> {
+    const results: ApiResponse = await es_client.search({
+        index: chain + '-block-*',
+        size: 1,
+        body: {
+            query: {bool: {filter: {match_all: {}}}},
+            sort: [{block_num: {order: "desc"}}],
+            track_total_hits: true,
+            size: 1
+        }
+    });
+
+    let lastBlock = getLastResult(results);
+    let totalBlocks = results.body.hits.total.value || 1;
+
+    return [lastBlock, totalBlocks];
+}
+
+
 export async function getLastIndexedABI(es_client: Client, chain: string) {
     const results: ApiResponse = await es_client.search({
         index: chain + '-abi-*',


### PR DESCRIPTION
For the validator (and probably all the Hyperion providers and users as well) it would be helpful to not only know the last indexed block but also the total amount of indexed blocks to not only see whether a Hyperion database is up-to-date but also if it's complete. I've added a query that achieves this. 

We already enabled this on our Hyperion3 API nodes, you can see it here for example: https://wax.eosn.io/v2/health

