### PR TITLE
Correct offset accuracy when system timezone is not UTC

### DIFF
--- a/api/routes/v2/health/health.ts
+++ b/api/routes/v2/health/health.ts
@@ -20,7 +20,7 @@ async function checkNodeos(fastify: FastifyInstance) {
     try {
         const results = await rpc.get_info();
         if (results) {
-            const diff = (new Date().getTime()) - (new Date(results.head_block_time).getTime());
+            const diff = (new Date().getTime()) - (new Date(results.head_block_time + '+00:00').getTime());
             return createHealth('NodeosRPC', 'OK', {
                 head_block_num: results.head_block_num,
                 head_block_time: results.head_block_time,


### PR DESCRIPTION
Currently if the system timezone is not UTC the `time_offset` field in the health output gets skewed. This change corrects that by forcing `head_block_time` to be UTC when parsing it for the diff calculation.