### PR TITLE
API logs need timestamp

### DIFF
--- a/definitions/ecosystem_settings.js
+++ b/definitions/ecosystem_settings.js
@@ -28,6 +28,7 @@ function addApiServer(chainName, threads) {
     autorestart: true,
     exp_backoff_restart_delay: 100,
     watch: false,
+    time: true, // include timestamps in pm2 logs
     env: {
       CONFIG_JSON: 'chains/' + chainName + '.config.json',
     },


### PR DESCRIPTION
This fix will make sure the api logs gets timestamped.