### PR TITLE
Redis: tolerate READONLY on startup + surface Sentinel fields in RedisConfig

### DIFF
--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -437,8 +437,27 @@ class HyperionApiServer {
 
       this.setupIndexerController();
 
-      // remove ES status key
-      await this.fastify.redis.del(`${this.chain}::es_status`);
+      // Remove ES status cache key so the first /v2/health after startup
+      // recomputes from ES rather than serving stale cached data.
+      // Tolerate READONLY: if the client is momentarily connected to a
+      // Redis replica (happens transiently during Sentinel failover, or
+      // permanently if the API is misconfigured to point at a replica),
+      // this DEL would throw and kill the process on startup. The delete
+      // is a cache-invalidation hint, not load-bearing — drop the error
+      // with a warning and continue. Other errors still propagate.
+      try {
+        await this.fastify.redis.del(`${this.chain}::es_status`);
+      } catch (e: any) {
+        if (typeof e?.message === 'string' && e.message.includes('READONLY')) {
+          hLog(
+            `Skipped startup cache invalidation (Redis client on a read-only replica). ` +
+            `Harmless during Sentinel failover; if persistent, check connections.redis ` +
+            `points at the primary or uses Sentinel mode.`
+          );
+        } else {
+          throw e;
+        }
+      }
     } catch (err) {
       hLog(err);
       process.exit(1);

--- a/src/indexer/modules/master.ts
+++ b/src/indexer/modules/master.ts
@@ -1531,8 +1531,26 @@ export class HyperionMaster {
             }
         );
 
-        // Remove first indexed block from cache (v2/health)
-        await this.ioRedisClient.del(`${this.manager.chain}::fib`);
+        // Remove first indexed block from cache (v2/health).
+        // Tolerate READONLY: if ioredis is momentarily connected to a
+        // Redis replica (transient during Sentinel failover), this DEL
+        // would throw and kill startup. The delete is a cache-invalidation
+        // hint — if it fails, the stale cache expires on its own next read
+        // cycle. Non-READONLY errors still propagate.
+        try {
+            await this.ioRedisClient.del(`${this.manager.chain}::fib`);
+        } catch (e: any) {
+            if (typeof e?.message === 'string' && e.message.includes('READONLY')) {
+                hLog(
+                    `Skipped ${this.manager.chain}::fib cache invalidation ` +
+                    `(Redis client on a read-only replica). Harmless during ` +
+                    `Sentinel failover; if persistent, check connections.redis ` +
+                    `points at the primary or uses Sentinel mode.`
+                );
+            } else {
+                throw e;
+            }
+        }
 
         let rpcChainId = '';
         let configuredChainId = this.manager.conn.chains[this.chain].chain_id;

--- a/src/interfaces/hyperionConnections.ts
+++ b/src/interfaces/hyperionConnections.ts
@@ -29,9 +29,34 @@ export interface HyperionChainData {
     control_port: number;
 }
 
+/**
+ * Redis connection config. The entire object is handed to ioredis via
+ * `new Redis(conn.redis)` (see api/server.ts, indexer/modules/master.ts,
+ * indexer/workers/ds-pool.ts, api/socketManager.ts), so any ioredis
+ * option works in practice. The previous form of this interface only
+ * declared `host` and `port`, which obscured the fact that auth and
+ * Sentinel mode are both supported. The common fields are now surfaced
+ * explicitly; `[key: string]: any` preserves pass-through for the rest.
+ *
+ * Single-primary mode: set `host` + `port`.
+ * Sentinel mode: omit `host`/`port`, set `sentinels[]` + `name`.
+ */
 export interface RedisConfig {
-    host: string;
-    port: number;
+    host?: string;
+    port?: number;
+    // ACL auth for the primary (Redis 6+).
+    username?: string;
+    password?: string;
+    db?: number;
+    tls?: Record<string, unknown>;
+    // Sentinel mode: ioredis queries the sentinel quorum to locate the
+    // current primary. Host/port above should be omitted when this is set.
+    sentinels?: { host: string; port: number }[];
+    name?: string;
+    sentinelUsername?: string;
+    sentinelPassword?: string;
+    // Forward any other ioredis option verbatim.
+    [key: string]: unknown;
 }
 
 export interface MongoDbConfig {

--- a/src/interfaces/hyperionConnections.ts
+++ b/src/interfaces/hyperionConnections.ts
@@ -36,7 +36,7 @@ export interface HyperionChainData {
  * option works in practice. The previous form of this interface only
  * declared `host` and `port`, which obscured the fact that auth and
  * Sentinel mode are both supported. The common fields are now surfaced
- * explicitly; `[key: string]: any` preserves pass-through for the rest.
+ * explicitly; `[key: string]: unknown` preserves pass-through for the rest.
  *
  * Single-primary mode: set `host` + `port`.
  * Sentinel mode: omit `host`/`port`, set `sentinels[]` + `name`.


### PR DESCRIPTION
## Summary

Two small fixes for operating Hyperion against a Redis+Sentinel cluster.

### 1. Surface auth + Sentinel fields in `RedisConfig` interface

`RedisConfig` previously declared only `host` and `port`. But the config loader (`src/indexer/modules/config.ts:129-144`) is plain `JSON.parse`, and the client is constructed with `new Redis(conn.redis)` at four sites:

- `src/api/server.ts:161`
- `src/indexer/modules/master.ts:205`
- `src/indexer/workers/ds-pool.ts:100`
- `src/api/socketManager.ts:72`

So any ioredis option — `username`, `password`, `tls`, `db`, `sentinels`, `name`, etc. — already works today via passthrough, but nobody can tell from the types, and Sentinel mode is undocumented.

This PR declares the common fields explicitly (ACL auth + Sentinel mode) while preserving passthrough with `[key: string]: unknown`. No runtime change; just makes the supported surface discoverable in the types.

### 2. Tolerate READONLY on startup cache invalidation

`HyperionApiServer.startServer()` does an unconditional `DEL ${chain}::es_status` to invalidate the health cache. If the client is connected to a Redis replica at that moment, Redis rejects the write with:

```
ReplyError: READONLY You can't write against a read only replica.
  command: { name: 'del', args: [ 'libremainnet::es_status' ] }
```

The process exits with status 1. pm2 restarts, loops.

Seen in the field on a 3-node Redis+Sentinel setup in two forms:
- Transiently, during Sentinel failover (ioredis reconnects to the new primary within seconds, but startup timing can catch a replica)
- Permanently, where API nodes had `connections.redis.host: 127.0.0.1` pointing at their local replica in the Sentinel topology

The `DEL` is a cache-invalidation hint — if it fails, the cached entry still expires via its 30-minute TTL. This patch wraps the call in a try/catch that logs `READONLY` and continues. Non-READONLY errors still propagate.

No behavior change for single-primary deployments.

## Test plan

- [x] `tsc --noEmit` passes with the new interface
- [x] Verified in production against a 3-node Redis+Sentinel cluster — fixes crash-loop on replica-connected API nodes
- [ ] Integration tests would be good to add but the repo doesn't currently exercise the Redis startup path directly

## Context

We're running Hyperion 4.0.5 against Libre mainnet and testnet with a Redis+Sentinel topology. The Sentinel mode via interface passthrough has been working cleanly once we removed the hardcoded `127.0.0.1` — hence the two-part PR (document that it's supported + stop crash-looping when a replica is in the picture).

Related source-cited operator docs (independent, published as a resource for other Hyperion operators): https://github.com/rwcii/hyperion-operator-reference — see `06-redis-topology.md` in particular for the full keyspace map and Sentinel passthrough discussion that motivated this PR.