### PR TITLE
fix: prepend https:// to x-hyperion-server header for explorer SSR

### DIFF
--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -776,7 +776,7 @@ class HyperionApiServer {
               return {
                 ...headers,
                 'x-hyperion-chain': this.manager.chain,
-                'x-hyperion-server': this.manager.config.api.server_name.startsWith('http') ? this.manager.config.api.server_name : `https://${this.manager.config.api.server_name}`,
+                'x-hyperion-server': this.manager.config.api.server_name.includes('://') ? this.manager.config.api.server_name : `https://${this.manager.config.api.server_name}`,
               };
             },
           },

--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -776,7 +776,7 @@ class HyperionApiServer {
               return {
                 ...headers,
                 'x-hyperion-chain': this.manager.chain,
-                'x-hyperion-server': this.manager.config.api.server_name,
+                'x-hyperion-server': this.manager.config.api.server_name.startsWith('http') ? this.manager.config.api.server_name : `https://${this.manager.config.api.server_name}`,
               };
             },
           },


### PR DESCRIPTION
## Summary
The explorer SSR uses `new URL()` to parse the `x-hyperion-server` proxy header value. The `server_name` config field is a bare hostname (e.g. `api.libre.cryptobloks.io`), and `new URL('api.libre.cryptobloks.io')` throws `ERR_INVALID_URL`.

This causes SSR to skip the metadata fetch entirely — no chain logo, provider info, or metadata renders in the explorer.

## Fix
Prepend `https://` to the header value when `server_name` doesn't already include a scheme.

## Related
The explorer also has a client-side fallback bug where it never retries when SSR fails — see eosrio/hyperion-explorer#1. Both fixes are needed for reliable explorer rendering.

## Test plan
- Verify `/explorer/` SSR output includes populated transfer state with logo URL
- Verify `x-hyperion-server` header includes `https://` prefix
- Verify `/v2/health` `host` field is unaffected (reads `server_name` directly)