### PR TITLE
ci: run Build & Test on dev branch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,9 +2,9 @@ name: Build & Test
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "main", "dev" ]
   pull_request:
-    branches: [ "main" ]
+    branches: [ "main", "dev" ]
 
 jobs:
   build:


### PR DESCRIPTION
First PR under the new branching model (`main` = tags/stable, `dev` = active work).

**What:** adds `dev` to `build.yml`'s `push` and `pull_request` branch filters.

**Why:** `build.yml` only triggered on `main`, so PRs into `dev` got no CI — bugs would only surface at the `dev`→`main` release PR, defeating the point of CI-gating `main`. Now the Node 22.x/24.x build + `bun test tests/unit` matrix runs on every `dev` push/PR too.

Also serves as the end-to-end validation of the new `main` branch protection (PR required, `build (22.x)` + `build (24.x)` required, 1 approval, no force-push).