### PR TITLE
fix(deserializer): heatmap routing drops all actions for unassigned contracts when ds_pool_size = 1

### DIFF
--- a/src/indexer/workers/deserializer.ts
+++ b/src/indexer/workers/deserializer.ts
@@ -609,7 +609,14 @@ export default class MainDSWorker extends HyperionWorker {
             }
         }
 
-        let selected_q = 1;
+        // Heatmap worker ids in dsPoolMap[_code][2] are 0-indexed (master builds them
+        // with `for (let i = 0; i < pool_size; i++)`), and the `selected_q += 1` below
+        // converts a 0-indexed worker id to its 1-indexed ds_pool queue. Initialize to 0
+        // so that a contract with no heatmap assignment falls back to the FIRST pool
+        // worker (queue ds_pool:1). Previously this was 1, so unassigned contracts routed
+        // to a non-existent ds_pool:2 — silently dropping all their action traces when
+        // ds_pool_size is 1 (the unrouted-queue publish is a no-op).
+        let selected_q = 0;
         const _code = first_action.act.account;
 
         switch (this.conf.scaling.routing_mode) {


### PR DESCRIPTION
## Problem

With `scaling.routing_mode: "heatmap"` and `scaling.ds_pool_size: 1`, the indexer ingests blocks and deltas correctly but `get_actions` returns 0 and `/v2/health` reports Elasticsearch "Error" because the `{chain}-action-*` index is never created. All action traces are silently dropped.

## Root cause

In `MainDSWorker.routeToPool` (`src/indexer/workers/deserializer.ts`), the heatmap path uses 0-indexed worker ids from `dsPoolMap[code][2]` and converts them to a 1-indexed `ds_pool:N` queue with `selected_q += 1`.

`selected_q` was initialized to `1`. When a contract has no heatmap assignment yet — empty `dsPoolMap` on a fresh/low-traffic chain, or any contract not seen since the last `update_pool_map` IPC update — the assignment block is skipped, `selected_q` stays `1`, and `+= 1` makes it `2`. Traces are published to `{chain}:ds_pool:2`.

But ds_pool workers are created in `master.ts` `setupDSPool()` with `local_id = i + 1` for `i in 0..ds_pool_size-1`, consuming queues `ds_pool:1..ds_pool_size`. With `ds_pool_size: 1` only `ds_pool:1` exists, so a default-exchange publish to the unrouted `ds_pool:2` is a no-op and the traces are lost. Deployments with `ds_pool_size >= 2` happen to have a `ds_pool:2` consumer, so they never observe this.

The heatmap worker ids in `dsPoolMap[code][2]` are 0-indexed (master builds them with `for (let i = 0; i < pool_size; i++) proposedWorkers.push(i)`), and `selected_q += 1` is exactly the 0→1-index conversion. The init value should therefore represent 0-indexed worker `0`, i.e. the first pool worker.

## Fix

Initialize `selected_q` to `0` instead of `1`, so an unassigned contract falls back to the first pool worker (queue `ds_pool:1`). `round_robin` reassigns `selected_q` and `default` exits, so neither relies on the initial value.

## Workarounds (for affected users on older builds)

- Set `scaling.routing_mode: "round_robin"`, or
- Set `scaling.ds_pool_size: 2` or higher.

## Verification

`tsc` compiles cleanly with no errors. Reproduced and fixed against a local Antelope **Spring 1.2.2** node: before the fix, blocks/deltas indexed but `get_actions` = 0 and ES health = Error; after, a clean re-index produced the chain's full action history (transfer/create/issue/setup/setfeesmap/setcode/newaccount/…) with all four `/v2/health` services OK.

## Optional follow-up (not in this PR)

A startup warning when `routing_mode === "heatmap" && ds_pool_size < 2` would surface the (now-functional but pointless) single-worker-heatmap config explicitly. Happy to add it here or separately if you'd like.