### PR TITLE
fix(cli): resolve transfer struct via action type in sync-accounts (get_tokens missing balances)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased (dev)
+
+### Fixes
+
+*   **`/v2/state/get_tokens` missing balances — token-contract detection in `sync accounts`**: `./hyp-control sync accounts` (and `sync all`) resolved a contract's transfer parameter struct by the hard-coded struct name `"transfer"`. Per the ABI spec the struct backing an action is named by the action's `type` field, which is frequently *not* the action name — e.g. several contracts declare a fully standard transfer (`from:name, to:name, quantity:asset, memo:string`) under the struct name `transfer_token`. Those contracts were silently skipped, so their balances were never backfilled into the MongoDB `accounts` collection and `get_tokens` returned only the symbols the live indexer happened to capture — producing a "same contract, some symbols present and some missing" result on upgraded nodes. The struct is now resolved through the transfer action's declared `type`. **After upgrading, re-run `./hyp-control sync accounts <chain>` (or `sync all`) to backfill the previously skipped contracts.**
+
 ## 4.0.7 (2026-05-16)
 
 > **4.0.6 was skipped.** The 4.0.6 version sat on `main` untagged for a period and some operators deployed it directly from `main` before any release tag existed. To avoid ambiguity between those pre-tag production deployments and the official artifact, this work is released as **4.0.7**. There is no separate 4.0.6 entry. Going forward, `main` only advances to tagged releases and active development happens on `dev`.

--- a/src/cli/sync-modules/sync-accounts.ts
+++ b/src/cli/sync-modules/sync-accounts.ts
@@ -68,18 +68,25 @@ export class AccountSynchronizer extends Synchronizer<IAccount> {
                 const abi = await this.client.v1.chain.get_abi(contract);
                 const tables = new Set(abi.abi?.tables?.map(value => value.name));
                 if (tables.has("accounts") && tables.has("stat")) {
-                    const actions = new Set(abi.abi?.actions?.map(value => value.name));
-                    if (actions.has("transfer")) {
-                        const transferType = abi.abi?.structs?.find(s => s.name === 'transfer');
+                    // Resolve the transfer parameter struct through the transfer action's
+                    // declared `type`, not the literal name "transfer". Per the ABI spec the
+                    // struct backing an action is named by the action's `type` field, which is
+                    // frequently NOT the action name — e.g. the paycash contracts (token.pcash,
+                    // cashescashes, swap.pcash, ...) declare a standard transfer under the struct
+                    // name "transfer_token". Looking the struct up by name === "transfer" returned
+                    // undefined and silently dropped these valid token contracts from the backfill.
+                    const transferAction = abi.abi?.actions?.find(a => a.name === "transfer");
+                    if (transferAction) {
+                        const transferType = abi.abi?.structs?.find(s => s.name === transferAction.type);
                         if (transferType && transferType.fields) {
                             const fields = transferType.fields;
                             let valid = true;
                             for (let i = 0; i < transferFields.length; i++) {
-                                if ((fields[i].name === "from" || fields[i].name === "to") && fields[i].type === 'account_name') {
+                                if (fields[i] && (fields[i].name === "from" || fields[i].name === "to") && fields[i].type === 'account_name') {
                                     valid = true;
                                     continue;
                                 }
-                                if (fields[i].name !== transferFields[i].name || fields[i].type !== transferFields[i].type) {
+                                if (!fields[i] || fields[i].name !== transferFields[i].name || fields[i].type !== transferFields[i].type) {
                                     console.error(`Invalid token contract ${contract} ->> ${fields.map(f => (f.name + "(" + f.type + ")").padEnd(24, " ")).join('  ')}`);
                                     valid = false;
                                     break;

--- a/src/cli/sync-modules/sync-accounts.ts
+++ b/src/cli/sync-modules/sync-accounts.ts
@@ -82,7 +82,7 @@ export class AccountSynchronizer extends Synchronizer<IAccount> {
                             const fields = transferType.fields;
                             let valid = true;
                             for (let i = 0; i < transferFields.length; i++) {
-                                if (fields[i] && (fields[i].name === "from" || fields[i].name === "to") && fields[i].type === 'account_name') {
+                                if (fields[i] && fields[i].name === transferFields[i].name && fields[i].type === 'account_name') {
                                     valid = true;
                                     continue;
                                 }


### PR DESCRIPTION
## Problem

Operators report `/v2/state/get_tokens` returning an incomplete token list after upgrading (e.g. `bu.klnk` shows 13/37 tokens), with the tell-tale symptom that **some symbols of the same contract show while others are missing**.

## Root cause

`AccountSynchronizer.scanABIs()` decides whether a contract is a token contract before backfilling balances. It looked up the transfer parameter struct by the **hard-coded struct name `"transfer"`**:

```ts
const transferType = abi.abi?.structs?.find(s => s.name === 'transfer');
```

Per the ABI spec, the struct backing an action is named by the **action's `type` field**, which is frequently *not* the action name. Several real token contracts declare a fully standard transfer (`from:name, to:name, quantity:asset, memo:string`) under a differently-named struct — e.g. the paycash contracts use **`transfer_token`**. For those, the lookup returned `undefined`, the field validation never ran, and the contract was **silently skipped** → its balances were never backfilled into the MongoDB `accounts` collection.

The live indexer's `*:accounts` handler has no such requirement, so it captured whatever balances changed post-upgrade — hence "same contract, some symbols present, some missing."

## Fix

Resolve the transfer struct through the transfer action's declared `type`, and guard against short field arrays.

## Verification (against `api.eosrio.io`)

Applying the old vs new detection to the contracts held by `bu.klnk` + a sample from `eosriobrazil`:

- **current**: accepts 12/22
- **fixed**: accepts 22/22
- **recovered** (current SKIP → now accept): `cashescashes, token.pcash, swap.pcash, jqpua4jqkqwz, testnewswap1, testrenminbi, testrublesrb, testuralsurl, uralsuralsru, testusdbxusd`

All recovered contracts have `accounts`+`stat` tables, an `accounts` row of `balance:asset`, and a `transfer` action whose `transfer_token` struct is exactly `from,to,quantity,memo`. Standard-transfer contracts are unaffected. `tsc --noEmit` passes.

## Operator action after merge

Pull, rebuild, then re-run `./hyp-control sync accounts <chain>` (or `sync all <chain>`) to backfill the previously skipped contracts.