### PR TITLE
improve(cli): accurate live progress for sync-accounts

### DIFF
--- a/src/cli/sync-modules/sync-accounts.ts
+++ b/src/cli/sync-modules/sync-accounts.ts
@@ -8,12 +8,13 @@ export class AccountSynchronizer extends Synchronizer<IAccount> {
     private accountCollection?: Collection<IAccount>;
     private contractAccounts: string[] = [];
     private tokenContracts: string[] = [];
-    private totalScopes: number = 0;
-    private processedScopes: number = 0;
-    private totalScopesToProcess: number = 0;
+    private completedContracts: number = 0;
+    private totalContracts: number = 0;
     private currentContractIndex: number = 0;
     private currentContract: string = '';
     private currentScope: string = '';
+    private currentContractScopes: number = 0; // holder scopes processed in the current contract
+    private totalScopesProcessed: number = 0;  // holder scopes processed across all contracts
     private contractFilter?: string;
 
     constructor(chain: string, contractFilter?: string) {
@@ -109,6 +110,7 @@ export class AccountSynchronizer extends Synchronizer<IAccount> {
             const contract = this.tokenContracts[i];
             this.currentContract = contract;
             this.currentContractIndex = i;
+            this.currentContractScopes = 0;
             console.log(`[DEBUG] Starting contract ${i + 1}/${this.tokenContracts.length}: ${contract}`);
             
             let lowerBound: string = '';
@@ -143,12 +145,14 @@ export class AccountSynchronizer extends Synchronizer<IAccount> {
                     } catch (e: any) {
                         console.log(`Failed to check balance ${row.scope}@${contract} - ${e.message}`);
                     }
+                    this.currentContractScopes++;
+                    this.totalScopesProcessed++;
                 }
                 lowerBound = scopes.more;
             } while (lowerBound !== '');
-            
+
             // Mark this contract as processed
-            this.processedScopes = i + 1;
+            this.completedContracts = i + 1;
             console.log(`[DEBUG] Completed contract ${i + 1}/${this.tokenContracts.length}: ${contract}`);
         }
         console.log(`[DEBUG] All contracts processed`);
@@ -169,7 +173,7 @@ export class AccountSynchronizer extends Synchronizer<IAccount> {
         
         await this.scanABIs();
         console.log(`Number of validated token contracts: ${this.tokenContracts.length}`);
-        this.totalScopesToProcess = this.tokenContracts.length;
+        this.totalContracts = this.tokenContracts.length;
 
         await this.setupMongo();
 
@@ -184,17 +188,24 @@ export class AccountSynchronizer extends Synchronizer<IAccount> {
                 }
                 return;
             }
-            const progressPercent = this.totalScopesToProcess > 0 ? ((this.processedScopes / this.totalScopesToProcess) * 100).toFixed(2) : '0.00';
-            
-            let statusMessage = '';
-            if (this.processedScopes >= this.totalScopesToProcess) {
+            // Percentage is driven by completed contracts (the only total known up front).
+            // The holder/balance counters below move continuously so a long single-contract
+            // sync no longer looks stuck at 0%.
+            const progressPercent = this.totalContracts > 0 ? ((this.completedContracts / this.totalContracts) * 100).toFixed(1) : '0.0';
+
+            let statusMessage: string;
+            if (this.completedContracts >= this.totalContracts) {
                 statusMessage = 'finalizing database writes...';
+            } else if (this.currentContract) {
+                // currentContractIndex is 0-based and set when a contract starts, so +1 reflects the contract in progress
+                const contractPos = Math.min(this.currentContractIndex + 1, this.totalContracts);
+                statusMessage = `contract ${contractPos}/${this.totalContracts} ${this.currentContract} (${this.currentContractScopes} holders) - current: ${this.currentScope || '...'}`;
             } else {
-                statusMessage = this.currentContract ? `${this.currentScope}@${this.currentContract}` : 'initializing...';
+                statusMessage = 'initializing...';
             }
-            
+
             const timestamp = new Date().toISOString().split('T')[1].split('.')[0]; // HH:MM:SS format
-            console.log(`[${timestamp}] Progress: ${this.processedScopes}/${this.totalScopesToProcess} (${progressPercent}%) - ${statusMessage} - ${this.totalItems} accounts`);
+            console.log(`[${timestamp}] ${progressPercent}% | holders scanned: ${this.totalScopesProcessed} | balances: ${this.totalItems} | ${statusMessage}`);
         }, 1000);
 
         try {

--- a/src/cli/sync-modules/sync-accounts.ts
+++ b/src/cli/sync-modules/sync-accounts.ts
@@ -111,6 +111,7 @@ export class AccountSynchronizer extends Synchronizer<IAccount> {
             this.currentContract = contract;
             this.currentContractIndex = i;
             this.currentContractScopes = 0;
+            this.currentScope = '';
             console.log(`[DEBUG] Starting contract ${i + 1}/${this.tokenContracts.length}: ${contract}`);
             
             let lowerBound: string = '';
@@ -194,7 +195,7 @@ export class AccountSynchronizer extends Synchronizer<IAccount> {
             const progressPercent = this.totalContracts > 0 ? ((this.completedContracts / this.totalContracts) * 100).toFixed(1) : '0.0';
 
             let statusMessage: string;
-            if (this.completedContracts >= this.totalContracts) {
+            if (this.totalContracts > 0 && this.completedContracts >= this.totalContracts) {
                 statusMessage = 'finalizing database writes...';
             } else if (this.currentContract) {
                 // currentContractIndex is 0-based and set when a contract starts, so +1 reflects the contract in progress


### PR DESCRIPTION
## Why

Follow-up to #170. An operator running `./hyp-control sync accounts eos token.pcash` saw the progress line stuck at `0/1 (0.00%)` for the whole run even though it was working (`Processed 448550 accounts`). The bar was driven by **completed-contract** count under misleading field names (`processedScopes`/`totalScopesToProcess` actually counted *contracts*), so a single-contract sync only moves 0% → 100% at the very end.

## Changes

- Rename `processedScopes`/`totalScopesToProcess` → `completedContracts`/`totalContracts`; remove the unused `totalScopes`.
- Track holder scopes processed per-contract (`currentContractScopes`) and overall (`totalScopesProcessed`), and surface the running **holders scanned** + **balances** counters — these move continuously.
- Show the contract **currently in progress** (`currentContractIndex + 1`) instead of only the last completed one.

The percentage stays contract-granular (the only total known up front — `get_table_by_scope` gives no cheap holder count), but the moving counters make long single-contract runs legible.

## New output

```
single contract:
  [07:05:40] 0.0% | holders scanned: 433076 | balances: 435000 | contract 1/1 token.pcash (433076 holders) - current: s2hw24.pcash
multi-contract, mid-run:
  [07:05:40] 3.3% | holders scanned: 50000 | balances: 52310 | contract 5/120 eosio.token (1200 holders) - current: bu.klnk
finalizing:
  [07:05:40] 100.0% | holders scanned: 240000 | balances: 251000 | finalizing database writes...
```

No behavior change to the sync itself. `tsc --noEmit` passes.