### PR TITLE
feat(api): read-alias seam for tiered storage (use_read_aliases, default off)

### DIFF
--- a/src/api/routes/v1-history/get_actions/get_actions.ts
+++ b/src/api/routes/v1-history/get_actions/get_actions.ts
@@ -281,7 +281,7 @@ async function getActions(fastify: FastifyInstance, request: FastifyRequest) {
 
     const queryTimeout = fastify.manager.config.api.query_timeout || '10s';
     const esOpts = {
-        "index": fastify.manager.chain + '-action-*',
+        "index": fastify.manager.readIndexset('action'),
         "from": from || 0,
         "size": (size > getActionsLimit ? getActionsLimit : size),
         "timeout": queryTimeout,

--- a/src/api/routes/v1-history/get_controlled_accounts/get_controlled_accounts.ts
+++ b/src/api/routes/v1-history/get_controlled_accounts/get_controlled_accounts.ts
@@ -8,7 +8,7 @@ async function getControlledAccounts(fastify: FastifyInstance, request: FastifyR
     }
     let controlling_account = body["controlling_account"];
     const results = await fastify.elastic.search<any>({
-        index: fastify.manager.chain + '-action-*',
+        index: fastify.manager.readIndexset('action'),
         size: 100,
         query: {
             bool: {

--- a/src/api/routes/v1-history/get_transaction/get_transaction.ts
+++ b/src/api/routes/v1-history/get_transaction/get_transaction.ts
@@ -94,7 +94,7 @@ async function getTransaction(fastify: FastifyInstance, request: FastifyRequest)
             const idxPart = Math.ceil(blockHint / conf.settings.index_partition_size).toString().padStart(6, '0');
             indexPattern = fastify.manager.chain + `-action-${conf.settings.index_version}-${idxPart}`;
         } else {
-            indexPattern = fastify.manager.chain + '-action-*';
+            indexPattern = fastify.manager.readIndexset('action');
         }
         let pResults;
         try {

--- a/src/api/routes/v1-trace/get_block/get_block.ts
+++ b/src/api/routes/v1-trace/get_block/get_block.ts
@@ -77,7 +77,7 @@ async function getBlockTrace(fastify: FastifyInstance, request: FastifyRequest) 
 
             // lookup all actions on block
             const getActionsResponse = await fastify.elastic.search<any>({
-                index: fastify.manager.chain + "-action-*",
+                index: fastify.manager.readIndexset('action'),
                 size: fastify.manager.config.api.limits.get_actions || 1000,
                 query: {
                     bool: {

--- a/src/api/routes/v2-history/get_actions/get_actions.ts
+++ b/src/api/routes/v2-history/get_actions/get_actions.ts
@@ -50,7 +50,7 @@ async function getActions(fastify: FastifyInstance, request: FastifyRequest) {
 
     // Perform search
 
-    let indexPattern = fastify.manager.chain + '-action-*';
+    let indexPattern = fastify.manager.readIndexset('action');
     if (query.hot_only) {
         indexPattern = fastify.manager.chain + '-action';
     }

--- a/src/api/routes/v2-history/get_created_accounts/get_created_accounts.ts
+++ b/src/api/routes/v2-history/get_created_accounts/get_created_accounts.ts
@@ -9,7 +9,7 @@ async function getCreatedAccounts(fastify: FastifyInstance, request: FastifyRequ
     const {skip, limit} = getSkipLimit(query);
     const maxActions = fastify.manager.config.api.limits.get_created_accounts ?? 0;
     const results = await fastify.elastic.search<any>({
-        index: fastify.manager.chain + '-action-*',
+        index: fastify.manager.readIndexset('action'),
         from: skip || 0,
         size: (limit > maxActions ? maxActions : limit) || 100,
         query: {

--- a/src/api/routes/v2-history/get_creator/get_creator.ts
+++ b/src/api/routes/v2-history/get_creator/get_creator.ts
@@ -30,7 +30,7 @@ async function getCreator(fastify: FastifyInstance, request: FastifyRequest) {
     }
 
     const results = await fastify.elastic.search<any>({
-        index: fastify.manager.chain + '-action-*',
+        index: fastify.manager.readIndexset('action'),
         size: 1,
         query: {
             bool: {

--- a/src/api/routes/v2-history/get_deltas/get_deltas.ts
+++ b/src/api/routes/v2-history/get_deltas/get_deltas.ts
@@ -80,7 +80,7 @@ async function getDeltas(fastify: FastifyInstance, request: FastifyRequest) {
     applyTimeFilter(query, queryStruct);
 
     const results = await fastify.elastic.search<any>({
-        "index": fastify.manager.chain + '-delta-*',
+        "index": fastify.manager.readIndexset('delta'),
         "from": skip || 0,
         "size": (limit > maxDeltas ? maxDeltas : limit) || 10,
         query: queryStruct,

--- a/src/api/routes/v2-history/get_table_state/get_table_state.ts
+++ b/src/api/routes/v2-history/get_table_state/get_table_state.ts
@@ -20,7 +20,7 @@ async function getTableState(fastify: FastifyInstance, request: FastifyRequest) 
         after_key = query.after_key;
     }
     const results = await fastify.elastic.search<any, any>({
-        index: fastify.manager.chain + '-delta-*',
+        index: fastify.manager.readIndexset('delta'),
         query: {
             bool: {
                 must: mustArray

--- a/src/api/routes/v2-history/get_transaction/get_transaction.ts
+++ b/src/api/routes/v2-history/get_transaction/get_transaction.ts
@@ -78,7 +78,7 @@ async function getTransaction(fastify: FastifyInstance, request: FastifyRequest)
             const idxPart = Math.ceil(blockHint / conf.settings.index_partition_size).toString().padStart(6, '0');
             indexPattern = fastify.manager.chain + `-action-${conf.settings.index_version}-${idxPart}`;
         } else {
-            indexPattern = fastify.manager.chain + '-action-*';
+            indexPattern = fastify.manager.readIndexset('action');
         }
         let pResults;
         try {

--- a/src/api/routes/v2-state/get_key_accounts/get_key_accounts.ts
+++ b/src/api/routes/v2-state/get_key_accounts/get_key_accounts.ts
@@ -132,7 +132,7 @@ async function getKeyAccounts(fastify: FastifyInstance, request: FastifyRequest)
 
     // Fallback to action search
     const results = await fastify.elastic.search<any>({
-        index: fastify.manager.chain + '-action-*',
+        index: fastify.manager.readIndexset('action'),
         size: (limit > maxDocs ? maxDocs : limit) || 100,
         from: skip || 0,
         query: {

--- a/src/api/routes/v2-stats/get_action_usage/get_action_usage.ts
+++ b/src/api/routes/v2-stats/get_action_usage/get_action_usage.ts
@@ -3,7 +3,7 @@ import {timedQuery} from "../../../helpers/functions.js";
 
 async function getLastSeq(fastify: FastifyInstance, date: string) {
     const req = await fastify.elastic.search<any>({
-        index: fastify.manager.chain + '-action-*',
+        index: fastify.manager.readIndexset('action'),
         "size": 1,
         "query": {
             "bool": {
@@ -22,7 +22,7 @@ async function getLastSeq(fastify: FastifyInstance, date: string) {
 
 async function getTxCount(fastify: FastifyInstance, dateFrom: string, dateTo: string) {
     const req = await fastify.elastic.count({
-        index: fastify.manager.chain + '-action-*',
+        index: fastify.manager.readIndexset('action'),
         "query": {
             "bool": {
                 "must": [
@@ -37,7 +37,7 @@ async function getTxCount(fastify: FastifyInstance, dateFrom: string, dateTo: st
 
 async function getUniqueActors(fastify: FastifyInstance, dateFrom: string, dateTo: string) {
     const req = await fastify.elastic.search<any, any>({
-        index: fastify.manager.chain + '-action-*',
+        index: fastify.manager.readIndexset('action'),
         size: 0,
         "aggs": {
             "unique_actors": {

--- a/src/api/routes/v2-stats/get_resource_usage/get_resource_usage.ts
+++ b/src/api/routes/v2-stats/get_resource_usage/get_resource_usage.ts
@@ -48,7 +48,7 @@ async function getResourceUsage(fastify: FastifyInstance, request: FastifyReques
     }
 
     const results = await fastify.elastic.search<any, any>({
-        index: fastify.manager.chain + "-action-*",
+        index: fastify.manager.readIndexset('action'),
         ...searchBody
     });
     if (results) {

--- a/src/indexer/connections/manager.class.ts
+++ b/src/indexer/connections/manager.class.ts
@@ -46,6 +46,18 @@ export class ConnectionManager {
         this.prepareIngestClients();
     }
 
+    /**
+     * Read index target for a tiered type. With `settings.use_read_aliases` enabled, reads resolve
+     * through the per-type read alias (`<chain>-<type>-read`); otherwise the wildcard
+     * (`<chain>-<type>-*`). Physical index names are unchanged, so the wildcard stays a valid
+     * fallback and the flag is a safe, reversible toggle.
+     */
+    readIndexset(type: 'action' | 'delta'): string {
+        return this.config.settings.use_read_aliases
+            ? `${this.chain}-${type}-read`
+            : `${this.chain}-${type}-*`;
+    }
+
     get nodeosApiClient() {
         return new APIClient({fetch, url: this.conn.chains[this.chain].http});
     }

--- a/src/indexer/connections/manager.class.ts
+++ b/src/indexer/connections/manager.class.ts
@@ -53,7 +53,7 @@ export class ConnectionManager {
      * fallback and the flag is a safe, reversible toggle.
      */
     readIndexset(type: 'action' | 'delta'): string {
-        return this.config.settings.use_read_aliases
+        return this.config.settings.use_read_aliases === true
             ? `${this.chain}-${type}-read`
             : `${this.chain}-${type}-*`;
     }

--- a/src/indexer/modules/master.ts
+++ b/src/indexer/modules/master.ts
@@ -773,6 +773,13 @@ export class HyperionMaster {
                 if (cfg) {
                     const name = `${this.conf.settings.chain}-${index.type}`;
                     const { index_patterns, settings, mappings, aliases } = cfg;
+                    // Tiered types auto-join a per-type READ ALIAS when use_read_aliases is enabled, so
+                    // new partitions are query-visible via `<chain>-<type>-read` (the tiering substrate).
+                    const readAlias =
+                        this.conf.settings.use_read_aliases && (index.type === 'action' || index.type === 'delta')
+                            ? { [`${this.conf.settings.chain}-${index.type}-read`]: {} }
+                            : undefined;
+                    const tmplAliases = { ...(aliases || {}), ...(readAlias || {}) };
                     // Composable index template (the legacy `_template` API is deprecated). Each type's
                     // index_patterns are disjoint, so an index matches exactly one template — there are
                     // no legacy merge semantics to preserve. priority 200 keeps it above any
@@ -784,7 +791,7 @@ export class HyperionMaster {
                         template: {
                             settings,
                             ...(mappings ? { mappings } : {}),
-                            ...(aliases ? { aliases } : {})
+                            ...(Object.keys(tmplAliases).length ? { aliases: tmplAliases } : {})
                         }
                     });
                     if (!creation_status || !creation_status.acknowledged) {

--- a/src/indexer/modules/master.ts
+++ b/src/indexer/modules/master.ts
@@ -776,7 +776,7 @@ export class HyperionMaster {
                     // Tiered types auto-join a per-type READ ALIAS when use_read_aliases is enabled, so
                     // new partitions are query-visible via `<chain>-<type>-read` (the tiering substrate).
                     const readAlias =
-                        this.conf.settings.use_read_aliases && (index.type === 'action' || index.type === 'delta')
+                        this.conf.settings.use_read_aliases === true && (index.type === 'action' || index.type === 'delta')
                             ? { [`${this.conf.settings.chain}-${index.type}-read`]: {} }
                             : undefined;
                     const tmplAliases = { ...(aliases || {}), ...(readAlias || {}) };
@@ -791,7 +791,7 @@ export class HyperionMaster {
                         template: {
                             settings,
                             ...(mappings ? { mappings } : {}),
-                            ...(Object.keys(tmplAliases).length ? { aliases: tmplAliases } : {})
+                            ...(Object.keys(tmplAliases).length > 0 ? { aliases: tmplAliases } : {})
                         }
                     });
                     if (!creation_status || !creation_status.acknowledged) {

--- a/src/interfaces/hyperionConfig.ts
+++ b/src/interfaces/hyperionConfig.ts
@@ -82,6 +82,9 @@ export interface MainSettings {
     max_retained_blocks?: number;
     es_replicas: number;
     tiered_index_allocation?: TieredIndexAllocationSettings;
+    /** Route action/delta reads through the per-type read alias (`<chain>-<type>-read`) instead of
+     *  the `<chain>-<type>-*` wildcard. Default off; requires the read aliases to be installed. */
+    use_read_aliases?: boolean;
 }
 
 export interface IndexerConfigs {
@@ -443,6 +446,7 @@ export const HyperionSettingsConfigSchema = z.object({
     max_retained_blocks: z.number().optional(),
     es_replicas: z.number(),
     tiered_index_allocation: TieredIndexAllocationSettingsSchema.optional(),
+    use_read_aliases: z.boolean().optional(),
 });
 
 // Zod schema for scaling configurations


### PR DESCRIPTION
Second step of the v4.5 tiered-storage work (after the composable-template migration #172). Introduces the **per-type read-alias indirection** the payload-tiering cutover needs — and nothing else changes behavior yet.

## What
- `ConnectionManager.readIndexset(type)` → `<chain>-<type>-read` when `settings.use_read_aliases` is on, else the `<chain>-<type>-*` wildcard.
- `settings.use_read_aliases` flag (default **off**) + Zod schema.
- action/delta composable templates auto-join `<chain>-<type>-read` **when the flag is on**, so new partitions become query-visible via the alias.
- all **15** action/delta wildcard read sites now resolve through `readIndexset` (v1+v2 history/stats/state/trace).

## Why it's safe
- **Flag off (default) = byte-for-byte identical behavior** — `readIndexset` returns the same wildcard, and the template gets no alias.
- **Physical index names are unchanged**, so the `<chain>-<type>-*` wildcard remains a valid fallback. The flag is a per-cluster, instantly-reversible toggle (flip off → wildcard reads over the same indices).
- The alias blue-green cutover model (atomic `updateAliases`, zero gap/dup) was validated end-to-end on ES 9.x by `tests/e2e/tiering-alias-proto.ts`.

## Intentionally deferred (both safe to defer)
- **`install-aliases` migration CLI** — backfills the alias over *existing* partitions, which is what makes the flag actually enable-able. Until it lands, flipping the flag would only see new partitions, so the flag stays off. (Next PR.)
- **`get_transaction` block_hint → dual-physical** — the prototype showed ES `can_match` does **not** prune a numeric `block_num` range, so the hinted lookup must target the partition's hot+cold physical indices directly. That lands with the freeze/cutover work, where cold indices first come into existence and their naming is finalized. With no cold indices yet, today's exact-hot-index block_hint is still correct.

## Validation
- `tsc --noEmit` clean.
- **Merge gate:** full indexer+API run against `tests/e2e/docker-compose.yml` with the flag both off (no change) and on (templates carry the alias; new partitions auto-join).

## Docs
No operator-facing change yet (flag is off and not enable-able until `install-aliases`), so per our docs-in-sync rule the **hyperion-docs** `docs/tiered-storage` update lands with the enablement PR, where operators actually get a knob to turn.