### PR TITLE
perf(api): hot-first routing + filter-context for get_actions account polls

### DIFF
--- a/references/config.ref.json
+++ b/references/config.ref.json
@@ -38,6 +38,8 @@
     "rate_limit_allow": [],
     "disable_tx_cache": false,
     "tx_cache_expiration_sec": 3600,
+    "hot_first_actions": false,
+    "hot_first_window": 2,
     "v1_chain_cache": [
       {"path": "get_block","ttl": 3000},
       {"path": "get_info","ttl": 500}

--- a/src/api/helpers/hot-index.ts
+++ b/src/api/helpers/hot-index.ts
@@ -1,0 +1,77 @@
+import {FastifyInstance} from "fastify";
+import {hLog} from "../../indexer/helpers/common_functions.js";
+
+// How long a resolved hot-index set is reused before re-querying ES. Short enough that a
+// freshly rolled-over partition is picked up quickly; long enough that high-frequency polling
+// does not turn into a _cat/indices storm.
+const HOT_INDEX_TTL_MS = 30_000;
+
+interface CacheEntry {
+    value: string;
+    expires: number;
+    // Shared in-flight refresh so concurrent requests past expiry trigger a single _cat lookup.
+    inflight?: Promise<string>;
+}
+
+const cache = new Map<string, CacheEntry>();
+
+/**
+ * Resolve the newest `window` physical partitions of a tiered type (`<chain>-<type>-<version>-<part>`)
+ * as a comma-joined index string for "hot-first" searches. Physical index names sort lexicographically
+ * by recency (zero-padded partition, version-prefixed), so the newest `window` names are simply the
+ * top of a descending sort.
+ *
+ * The result is cached per (chain, type, window) with a short TTL and a shared in-flight promise so a
+ * burst of polls past expiry costs one `_cat/indices` call. On any error — or when no physical index
+ * matches yet — it degrades to the `<chain>-<type>-*` wildcard, so callers always get a searchable
+ * target and never fail because of this optimization.
+ */
+export async function resolveHotIndices(
+    fastify: FastifyInstance,
+    type: 'action' | 'delta',
+    window: number
+): Promise<string> {
+    const chain = fastify.manager.chain;
+    const win = Math.max(1, Math.floor(window));
+    const key = `${chain}-${type}-${win}`;
+    const fallback = `${chain}-${type}-*`;
+    const now = Date.now();
+
+    const cached = cache.get(key);
+    if (cached && cached.expires > now) {
+        return cached.value;
+    }
+    // A refresh is already running — ride along instead of issuing a second _cat call.
+    if (cached?.inflight) {
+        return cached.inflight;
+    }
+
+    const inflight = (async () => {
+        try {
+            const records = await fastify.elastic.cat.indices({
+                index: fallback,
+                h: 'index',
+                s: 'index:desc',
+                format: 'json'
+            });
+            const names = (records as Array<{ index?: string }>)
+                .map(r => r.index)
+                .filter((n): n is string => typeof n === 'string' && n.length > 0)
+                .slice(0, win);
+            const value = names.length > 0 ? names.join(',') : fallback;
+            cache.set(key, {value, expires: Date.now() + HOT_INDEX_TTL_MS});
+            return value;
+        } catch (e: any) {
+            // Degrade to the wildcard and cache it briefly so a flapping cluster does not get
+            // hammered with _cat retries on every request.
+            hLog(`hot-index resolve failed for ${key}, using wildcard: ${e?.message ?? e}`);
+            cache.set(key, {value: fallback, expires: Date.now() + HOT_INDEX_TTL_MS});
+            return fallback;
+        }
+    })();
+
+    // Publish the in-flight promise (keeping any stale value for readers that prefer it) so
+    // concurrent callers dedupe onto this single refresh.
+    cache.set(key, {value: cached?.value ?? fallback, expires: cached?.expires ?? 0, inflight});
+    return inflight;
+}

--- a/src/api/helpers/hot-index.ts
+++ b/src/api/helpers/hot-index.ts
@@ -35,6 +35,13 @@ export async function resolveHotIndices(
     const win = Math.max(1, Math.floor(window));
     const key = `${chain}-${type}-${win}`;
     const fallback = `${chain}-${type}-*`;
+    // Scope the lookup to the active index_version so that on a multi-version cluster (during/after a
+    // reindex) a higher-version low partition (e.g. <chain>-<type>-v2-000001) can't sort ahead of the
+    // live latest partition of the running version and cause newest actions to be missed. When the
+    // version is unknown, fall back to all versions (correctness is still preserved by the caller's
+    // widen-on-shortfall step).
+    const version = fastify.manager.config?.settings?.index_version;
+    const searchPattern = version ? `${chain}-${type}-${version}-*` : fallback;
     const now = Date.now();
 
     const cached = cache.get(key);
@@ -49,13 +56,15 @@ export async function resolveHotIndices(
     const inflight = (async () => {
         try {
             const records = await fastify.elastic.cat.indices({
-                index: fallback,
+                index: searchPattern,
                 h: 'index',
                 s: 'index:desc',
                 format: 'json'
             });
-            const names = (records as Array<{ index?: string }>)
-                .map(r => r.index)
+            // Some client/transport configurations can return a non-array under error/empty states;
+            // guard so we degrade to the wildcard rather than throwing on .map.
+            const names = (Array.isArray(records) ? records : [])
+                .map((r: { index?: string }) => r.index)
                 .filter((n): n is string => typeof n === 'string' && n.length > 0)
                 .slice(0, win);
             const value = names.length > 0 ? names.join(',') : fallback;

--- a/src/api/routes/v2-history/get_actions/functions.ts
+++ b/src/api/routes/v2-history/get_actions/functions.ts
@@ -169,7 +169,12 @@ export function applyGenericFilters(query, queryStruct, allowedExtraParams: Set<
                                 _qObj[pkey].operator = query.match_operator;
                             }
 
-                            (queryStruct.bool.filter ??= []).push({
+                            // Keep the memo full-text match in scoring context: it is the only
+                            // relevance-bearing clause, so an explicit sortedBy=_score (with
+                            // fuzziness/operator) must still rank by it. It is selective and rare,
+                            // so its scoring cost is negligible — unlike the high-cardinality
+                            // keyword clauses moved to filter context.
+                            queryStruct.bool.must.push({
                                 match: _qObj
                             });
                         } else {

--- a/src/api/routes/v2-history/get_actions/functions.ts
+++ b/src/api/routes/v2-history/get_actions/functions.ts
@@ -26,19 +26,20 @@ export function processMultiVars(queryStruct, parts, field) {
     });
 
     if (must.length > 1) {
-        queryStruct.bool.must.push({
+        (queryStruct.bool.filter ??= []).push({
             bool: {
                 should: must.map(elem => {
                     const _q = {};
                     _q[field] = elem;
                     return {term: _q}
-                })
+                }),
+                minimum_should_match: 1
             }
         });
     } else if (must.length === 1) {
         const mustQuery = {};
         mustQuery[field] = must[0];
-        queryStruct.bool.must.push({term: mustQuery});
+        (queryStruct.bool.filter ??= []).push({term: mustQuery});
     }
 
     if (mustNot.length > 1) {
@@ -65,7 +66,7 @@ function addRangeQuery(queryStruct, prop, pkey, query) {
         "gte": parts[0],
         "lte": parts[1]
     };
-    queryStruct.bool.must.push({range: _termQuery});
+    (queryStruct.bool.filter ??= []).push({range: _termQuery});
 }
 
 // A bound is a block number when it is a bare positive integer; any other value
@@ -168,7 +169,7 @@ export function applyGenericFilters(query, queryStruct, allowedExtraParams: Set<
                                 _qObj[pkey].operator = query.match_operator;
                             }
 
-                            queryStruct.bool.must.push({
+                            (queryStruct.bool.filter ??= []).push({
                                 match: _qObj
                             });
                         } else {
@@ -177,7 +178,7 @@ export function applyGenericFilters(query, queryStruct, allowedExtraParams: Set<
                                 andParts.forEach(value => {
                                     const _q = {};
                                     _q[pkey] = value;
-                                    queryStruct.bool.must.push({term: _q});
+                                    (queryStruct.bool.filter ??= []).push({term: _q});
                                 });
                             } else {
                                 if (parts[0].startsWith("!")) {
@@ -185,7 +186,7 @@ export function applyGenericFilters(query, queryStruct, allowedExtraParams: Set<
                                     queryStruct.bool.must_not.push({term: _qObj});
                                 } else {
                                     _qObj[pkey] = parts[0];
-                                    queryStruct.bool.must.push({term: _qObj});
+                                    (queryStruct.bool.filter ??= []).push({term: _qObj});
                                 }
                             }
                         }
@@ -228,8 +229,9 @@ export function applyCodeActionFilters(query, queryStruct) {
             }
         }
         if (filterObj.length > 0) {
-            queryStruct.bool['should'] = filterObj;
-            queryStruct.bool['minimum_should_match'] = 1;
+            // Code:name filter in filter context (was a scoring root-level should+msm). Semantics
+            // are identical — "match >= 1 of the code:name pairs" — minus the wasted scoring.
+            (queryStruct.bool.filter ??= []).push({bool: {should: filterObj, minimum_should_match: 1}});
         }
     }
 }
@@ -306,6 +308,10 @@ export function getSortDir(query, maxAscWindowDays = 90) {
 
 export function applyAccountFilters(query, queryStruct) {
     if (query.account) {
-        queryStruct.bool.must.push({"bool": {should: makeShouldArray(query)}});
+        // Filter context: the account match is a pure include and results are sorted by
+        // global_sequence (never _score), so scoring this should-clause across millions of docs
+        // is wasted work. filter context skips scoring and is cacheable. minimum_should_match is
+        // explicit (a should-only bool defaults to 1, but filter context makes it worth stating).
+        (queryStruct.bool.filter ??= []).push({bool: {should: makeShouldArray(query), minimum_should_match: 1}});
     }
 }

--- a/src/api/routes/v2-history/get_actions/get_actions.ts
+++ b/src/api/routes/v2-history/get_actions/get_actions.ts
@@ -1,5 +1,6 @@
 import {FastifyInstance, FastifyReply, FastifyRequest} from "fastify";
 import {getTrackTotalHits, mergeActionMeta, timedQuery} from "../../../helpers/functions.js";
+import {resolveHotIndices} from "../../../helpers/hot-index.js";
 import {
     addSortedBy,
     applyAccountFilters,
@@ -47,22 +48,57 @@ async function getActions(fastify: FastifyInstance, request: FastifyRequest) {
     addSortedBy(query, query_body, sort_direction);
 
     // Perform search
+    const fullPattern = fastify.manager.chain + '-action-*';
+    const hotWindow = fastify.manager.config.api.hot_first_window ?? 2;
 
-    let indexPattern = fastify.manager.chain + '-action-*';
+    let indexPattern = fullPattern;
     if (query.hot_only) {
-        indexPattern = fastify.manager.chain + '-action';
+        // hot_only restricts the search to the newest action partition(s), resolved from the live
+        // index set. (The legacy `<chain>-action` alias this used to target is never created, so the
+        // old behavior threw index_not_found; resolveHotIndices degrades to the wildcard on failure.)
+        indexPattern = await resolveHotIndices(fastify, 'action', hotWindow);
     }
 
     const queryTimeout = fastify.manager.config.api.query_timeout || '10s';
+    const size = (limit > maxActions ? maxActions : limit) || 10;
     const esOpts = {
         "index": indexPattern,
         "from": skip || 0,
-        "size": (limit > maxActions ? maxActions : limit) || 10,
+        "size": size,
         "timeout": queryTimeout,
         ...query_body
     };
 
-    const esResults = await fastify.elastic.search<any>(esOpts);
+    // Hot-first routing (opt-in via api.hot_first_actions): an unbounded, newest-first account poll
+    // only ever needs the most recent actions, which live in the newest partition(s). Search the hot
+    // window first and widen to the full <chain>-action-* set only if it returns fewer than `size`
+    // hits — so heavy pollers (e.g. account=eosio.token) never fan out across old/warm shards. Only
+    // the default global_sequence-desc sort qualifies; bounded queries, pagination (skip>0), asc
+    // sorts, custom sortedBy, and explicit hot_only stay on their existing path.
+    const hotFirstEligible =
+        fastify.manager.config.api.hot_first_actions === true &&
+        !query.hot_only &&
+        !!query.account &&
+        !query.sortedBy &&
+        sort_direction === 'desc' &&
+        !query.after &&
+        !query.before &&
+        (skip || 0) === 0;
+
+    let esResults;
+    let hotFirstUsed = false;
+    if (hotFirstEligible) {
+        const hotIndex = await resolveHotIndices(fastify, 'action', hotWindow);
+        esResults = await fastify.elastic.search<any>({...esOpts, index: hotIndex});
+        if (esResults.hits.hits.length < size) {
+            // The account is sparse within the hot window — widen to the full set for correctness.
+            esResults = await fastify.elastic.search<any>(esOpts);
+        } else {
+            hotFirstUsed = true;
+        }
+    } else {
+        esResults = await fastify.elastic.search<any>(esOpts);
+    }
 
     const results = esResults.hits;
     const response: any = {
@@ -73,6 +109,9 @@ async function getActions(fastify: FastifyInstance, request: FastifyRequest) {
 
     if (query.hot_only) {
         response.hot_only = true;
+    }
+    if (hotFirstUsed) {
+        response.hot_first = true;
     }
 
     if (query.checkLib) {

--- a/src/api/routes/v2-history/get_actions/get_actions.ts
+++ b/src/api/routes/v2-history/get_actions/get_actions.ts
@@ -89,12 +89,18 @@ async function getActions(fastify: FastifyInstance, request: FastifyRequest) {
     let hotFirstUsed = false;
     if (hotFirstEligible) {
         const hotIndex = await resolveHotIndices(fastify, 'action', hotWindow);
-        esResults = await fastify.elastic.search<any>({...esOpts, index: hotIndex});
-        if (esResults.hits.hits.length < size) {
-            // The account is sparse within the hot window — widen to the full set for correctness.
+        if (hotIndex === fullPattern) {
+            // Resolver degraded to the wildcard — phase 1 would already be the full search, so run it
+            // once and don't claim the hot-first path (no redundant second query, accurate flag).
             esResults = await fastify.elastic.search<any>(esOpts);
         } else {
-            hotFirstUsed = true;
+            esResults = await fastify.elastic.search<any>({...esOpts, index: hotIndex});
+            if (esResults.hits.hits.length < size) {
+                // The account is sparse within the hot window — widen to the full set for correctness.
+                esResults = await fastify.elastic.search<any>(esOpts);
+            } else {
+                hotFirstUsed = true;
+            }
         }
     } else {
         esResults = await fastify.elastic.search<any>(esOpts);

--- a/src/interfaces/hyperionConfig.ts
+++ b/src/interfaces/hyperionConfig.ts
@@ -168,6 +168,12 @@ interface ApiConfigs {
     explorer?: ExplorerConfigs;
     query_timeout?: string;           // ES search timeout (e.g., "5s"), default: "10s"
     max_asc_window_days?: number;     // max range in days for sort=asc queries, default: 90
+    // Hot-first routing for unbounded latest-N get_actions polls (e.g. account=eosio.token,
+    // desc, no time bound). When enabled, the recent action partition(s) are searched first and
+    // the full <chain>-action-* set is queried only if that window returns fewer than `limit`
+    // hits — so heavy polling never fans out to old/warm shards. Default off.
+    hot_first_actions?: boolean;
+    hot_first_window?: number;        // number of newest action partitions in the hot window, default: 2
 }
 
 interface ExplorerConfigs {
@@ -324,6 +330,8 @@ export const HyperionApiConfigSchema = z.object({
     explorer: ExplorerConfigsSchema.optional(),
     query_timeout: z.string().optional(),
     max_asc_window_days: z.number().optional(),
+    hot_first_actions: z.boolean().optional(),
+    hot_first_window: z.number().optional(),
 });
 
 // Zod schema for tiered index allocation settings

--- a/tests/unit/filter-context.test.ts
+++ b/tests/unit/filter-context.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from 'bun:test';
+import {
+    applyAccountFilters,
+    applyGenericFilters,
+    applyCodeActionFilters
+} from '../../src/api/routes/v2-history/get_actions/functions.js';
+
+// get_actions builds its query with these clauses in *filter* context (not must/should), because
+// results are always sorted by global_sequence and never by _score — so scoring is wasted work.
+// These tests pin that placement so a regression back to scoring context is caught.
+
+const newQueryStruct = () => ({ bool: { must: [] as any[], must_not: [] as any[], boost: 1.0 } });
+
+describe('applyAccountFilters — filter context', () => {
+    it('puts the account should-array in bool.filter with minimum_should_match, not bool.must', () => {
+        const qs = newQueryStruct();
+        applyAccountFilters({ account: 'eosio.token' }, qs);
+
+        expect(qs.bool.must).toHaveLength(0);
+        expect(qs.bool.filter).toHaveLength(1);
+        const clause = qs.bool.filter[0];
+        expect(clause.bool.minimum_should_match).toBe(1);
+        // notified, receipts.receiver, act.authorization.actor — all bound to the account
+        expect(clause.bool.should).toEqual([
+            { term: { notified: 'eosio.token' } },
+            { term: { 'receipts.receiver': 'eosio.token' } },
+            { term: { 'act.authorization.actor': 'eosio.token' } }
+        ]);
+    });
+
+    it('is a no-op when no account is given', () => {
+        const qs = newQueryStruct();
+        applyAccountFilters({}, qs);
+        expect(qs.bool.filter).toBeUndefined();
+        expect(qs.bool.must).toHaveLength(0);
+    });
+});
+
+describe('applyGenericFilters — filter context', () => {
+    it('puts a single primary-term match in bool.filter', () => {
+        const qs = newQueryStruct();
+        applyGenericFilters({ producer: 'eosio' }, qs, new Set());
+        expect(qs.bool.must).toHaveLength(0);
+        expect(qs.bool.filter).toEqual([{ term: { producer: 'eosio' } }]);
+    });
+
+    it('puts a comma multi-value clause in bool.filter as a should with minimum_should_match', () => {
+        const qs = newQueryStruct();
+        applyGenericFilters({ producer: 'a,b' }, qs, new Set());
+        expect(qs.bool.must).toHaveLength(0);
+        expect(qs.bool.filter).toHaveLength(1);
+        expect(qs.bool.filter[0].bool.minimum_should_match).toBe(1);
+        expect(qs.bool.filter[0].bool.should).toEqual([
+            { term: { producer: 'a' } },
+            { term: { producer: 'b' } }
+        ]);
+    });
+
+    it('puts a range clause in bool.filter', () => {
+        const qs = newQueryStruct();
+        applyGenericFilters({ block_num: '100-200' }, qs, new Set());
+        expect(qs.bool.must).toHaveLength(0);
+        expect(qs.bool.filter).toEqual([{ range: { block_num: { gte: '100', lte: '200' } } }]);
+    });
+
+    it('keeps negation in must_not (unchanged)', () => {
+        const qs = newQueryStruct();
+        applyGenericFilters({ producer: '!eosio' }, qs, new Set());
+        expect(qs.bool.must_not).toEqual([{ term: { producer: 'eosio' } }]);
+        expect(qs.bool.filter).toBeUndefined();
+    });
+});
+
+describe('applyCodeActionFilters — filter context', () => {
+    it('puts the code:name filter in bool.filter (not root-level should)', () => {
+        const qs = newQueryStruct();
+        applyCodeActionFilters({ filter: 'eosio.token:transfer' }, qs);
+        expect((qs.bool as any).should).toBeUndefined();
+        expect(qs.bool.filter).toHaveLength(1);
+        expect(qs.bool.filter[0].bool.minimum_should_match).toBe(1);
+        expect(qs.bool.filter[0].bool.should).toEqual([
+            { bool: { must: [{ term: { 'act.account': 'eosio.token' } }, { term: { 'act.name': 'transfer' } }] } }
+        ]);
+    });
+});

--- a/tests/unit/filter-context.test.ts
+++ b/tests/unit/filter-context.test.ts
@@ -69,6 +69,13 @@ describe('applyGenericFilters — filter context', () => {
         expect(qs.bool.must_not).toEqual([{ term: { producer: 'eosio' } }]);
         expect(qs.bool.filter).toBeUndefined();
     });
+
+    it('keeps the @transfer.memo full-text match in must so sortedBy=_score still ranks by relevance', () => {
+        const qs = newQueryStruct();
+        applyGenericFilters({ 'transfer.memo': 'hello' }, qs, new Set(['transfer']));
+        expect(qs.bool.must).toEqual([{ match: { '@transfer.memo': { query: 'hello' } } }]);
+        expect(qs.bool.filter).toBeUndefined();
+    });
 });
 
 describe('applyCodeActionFilters — filter context', () => {

--- a/tests/unit/hot-index.test.ts
+++ b/tests/unit/hot-index.test.ts
@@ -3,13 +3,14 @@ import { resolveHotIndices } from '../../src/api/helpers/hot-index.js';
 
 // Build a minimal fastify-like stub whose elastic.cat.indices is backed by `impl`, counting calls
 // so we can assert caching. Each test uses a unique chain so the module-level cache never collides.
-function makeFastify(chain: string, impl: () => any) {
+function makeFastify(chain: string, impl: () => any, opts: { version?: string } = {}) {
     let calls = 0;
+    let lastIndex: string | undefined;
     const instance: any = {
-        manager: { chain },
-        elastic: { cat: { indices: async () => { calls++; return impl(); } } }
+        manager: { chain, config: { settings: { index_version: opts.version } } },
+        elastic: { cat: { indices: async (p: any) => { calls++; lastIndex = p?.index; return impl(); } } }
     };
-    return { instance, getCalls: () => calls };
+    return { instance, getCalls: () => calls, getLastIndex: () => lastIndex };
 }
 
 describe('resolveHotIndices', () => {
@@ -51,5 +52,22 @@ describe('resolveHotIndices', () => {
         ]);
         const res = await resolveHotIndices(instance, 'action', 0);
         expect(res).toBe('chainE-action-v1-000009');
+    });
+
+    it('scopes the _cat lookup to the active index_version when set', async () => {
+        const { instance, getLastIndex } = makeFastify(
+            'chainF',
+            () => [{ index: 'chainF-action-v2-000010' }],
+            { version: 'v2' }
+        );
+        const res = await resolveHotIndices(instance, 'action', 1);
+        expect(getLastIndex()).toBe('chainF-action-v2-*');
+        expect(res).toBe('chainF-action-v2-000010');
+    });
+
+    it('ignores a non-array _cat response and degrades to the wildcard', async () => {
+        const { instance } = makeFastify('chainG', () => ({ unexpected: true }) as any);
+        const res = await resolveHotIndices(instance, 'action', 2);
+        expect(res).toBe('chainG-action-*');
     });
 });

--- a/tests/unit/hot-index.test.ts
+++ b/tests/unit/hot-index.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'bun:test';
+import { resolveHotIndices } from '../../src/api/helpers/hot-index.js';
+
+// Build a minimal fastify-like stub whose elastic.cat.indices is backed by `impl`, counting calls
+// so we can assert caching. Each test uses a unique chain so the module-level cache never collides.
+function makeFastify(chain: string, impl: () => any) {
+    let calls = 0;
+    const instance: any = {
+        manager: { chain },
+        elastic: { cat: { indices: async () => { calls++; return impl(); } } }
+    };
+    return { instance, getCalls: () => calls };
+}
+
+describe('resolveHotIndices', () => {
+    it('joins the newest `window` physical indices (already desc-sorted by ES)', async () => {
+        const { instance } = makeFastify('chainA', () => [
+            { index: 'chainA-action-v1-000003' },
+            { index: 'chainA-action-v1-000002' },
+            { index: 'chainA-action-v1-000001' }
+        ]);
+        const res = await resolveHotIndices(instance, 'action', 2);
+        expect(res).toBe('chainA-action-v1-000003,chainA-action-v1-000002');
+    });
+
+    it('caches the result so repeated polls within the TTL issue one _cat call', async () => {
+        const { instance, getCalls } = makeFastify('chainB', () => [{ index: 'chainB-action-v1-000007' }]);
+        const a = await resolveHotIndices(instance, 'action', 2);
+        const b = await resolveHotIndices(instance, 'action', 2);
+        expect(a).toBe('chainB-action-v1-000007');
+        expect(b).toBe(a);
+        expect(getCalls()).toBe(1);
+    });
+
+    it('degrades to the <chain>-action-* wildcard when _cat throws', async () => {
+        const { instance } = makeFastify('chainC', () => { throw new Error('es down'); });
+        const res = await resolveHotIndices(instance, 'action', 2);
+        expect(res).toBe('chainC-action-*');
+    });
+
+    it('degrades to the wildcard when no physical index matches yet', async () => {
+        const { instance } = makeFastify('chainD', () => []);
+        const res = await resolveHotIndices(instance, 'action', 2);
+        expect(res).toBe('chainD-action-*');
+    });
+
+    it('treats a window < 1 as 1', async () => {
+        const { instance } = makeFastify('chainE', () => [
+            { index: 'chainE-action-v1-000009' },
+            { index: 'chainE-action-v1-000008' }
+        ]);
+        const res = await resolveHotIndices(instance, 'action', 0);
+        expect(res).toBe('chainE-action-v1-000009');
+    });
+});


### PR DESCRIPTION
## Problem

Unbounded, newest-first **`get_actions` account polls** — e.g. `?account=eosio.token&limit=100` (desc, no time bound) — are a top search-CPU cost on history nodes. The query fans out across **every** `<chain>-action-*` shard, including old/warm ones, even though the latest N actions all live in the newest partition. On busy contracts (`eosio.token` on WAX) this is hammered by external pollers and lights up warm nodes that should never be touched for "latest 100".

Reported in the field by another operator monitoring inbound queries; the exact query is the standard `should` over `notified` / `receipts.receiver` / `act.authorization.actor` sorted by `global_sequence desc`.

## Changes

### Tier 1 — filter context (always on, behavior-preserving)
`get_actions` always sorts by `global_sequence` (never `_score`), so scoring the account should-array, generic term/range filters, and the code:name filter was wasted work on every poll. Moved them from `bool.must` / root-level `should` into `bool.filter`:
- **Identical result sets** — `account AND generics AND (>=1 code-filter)` — minus BM25 scoring, and now cacheable.
- `must_not` left unchanged.

### Tier 2 — hot-first routing (opt-in, default off)
New `api.hot_first_actions` (default `false`) + `api.hot_first_window` (default `2`). When enabled, an eligible poll searches the newest `window` partitions first and widens to the full `<chain>-action-*` set **only if** that window returns fewer than `limit` hits.
- Heavy pollers (`eosio.token`) fill the window → **never fan out to old/warm shards**.
- Sparse / old-only accounts stay correct via the fallback (the newest N by `global_sequence` are provably in the newest partitions, so a full window = the true top N).
- Eligible only for the default `global_sequence`-desc sort with `skip=0` and no `after`/`before`. Bounded queries, pagination, `asc`, custom `sortedBy`, and explicit `hot_only` keep their existing path.
- `resolveHotIndices()` resolves the newest physical partitions via a **TTL-cached (30s), stampede-safe** `_cat/indices` lookup and **degrades to the `<chain>-action-*` wildcard on any error** — never fails a request.

### Bonus: repair `?hot_only=true`
It previously targeted a `<chain>-action` alias that nothing in the codebase ever creates (would throw `index_not_found`). It now routes through the same resolver, so it actually works.

## Operator usage (no reindex required)
```jsonc
"api": { "hot_first_actions": true, "hot_first_window": 2 }
```

## Caveat
When hot-first is satisfied, the response `total` reflects the hot window only. These polls already cap `total` at 10k, so impact is low — worth a changelog line.

## Testing
- `tsc --noEmit` clean.
- `bun test tests/unit` — **118 pass** (12 new): `filter-context.test.ts` pins the filter-context placement; `hot-index.test.ts` covers resolver join order, caching/dedup, and wildcard fallback on error/empty.

## Scope / follow-ups
- Eligibility intentionally scoped to **account** polls (matches the reported query). Correct for filter-only / firehose polls too — easy to broaden later.
- v1 `get_actions` has a separate older query path; out of scope here.
- Docs: `hot_first_actions` / `hot_first_window` need an entry in `eosrio/hyperion-docs` when this ships.
