### PR TITLE
fix(api): declare hot_first in response schema so it isn't stripped

### DIFF
--- a/src/api/helpers/functions.ts
+++ b/src/api/helpers/functions.ts
@@ -781,6 +781,7 @@ export function extendResponseSchema(responseProps: any) {
         query_time_ms: {type: "number"},
         cached: {type: "boolean"},
         hot_only: {type: "boolean"},
+        hot_first: {type: "boolean"},
         lib: {type: "number"},
         last_indexed_block: {type: "number"},
         last_indexed_block_time: {type: "string"},

--- a/tests/unit/api-helpers.test.ts
+++ b/tests/unit/api-helpers.test.ts
@@ -152,6 +152,10 @@ describe('extendResponseSchema', () => {
         expect(props.cached).toBeDefined();
         expect(props.lib).toBeDefined();
         expect(props.total).toBeDefined();
+        // hot_only / hot_first must be declared or fast-json-stringify silently strips them
+        // from the response even when the handler sets them.
+        expect(props.hot_only).toBeDefined();
+        expect(props.hot_first).toBeDefined();
         expect(props.actions).toEqual({ type: 'array' });
     });
 });


### PR DESCRIPTION
Follow-up to #176. `get_actions` sets `response.hot_first` for observability, but `extendResponseSchema` never declared it — and fast-json-stringify only serializes declared properties, so the field was silently dropped from every response. That made it impossible to tell from the API whether hot-first routing engaged (it surfaced during live debugging of an operator deployment).

- Declare `hot_first` next to `hot_only` in `extendResponseSchema`.
- Assert both `hot_only` and `hot_first` in the schema unit test (would have caught this).

tsc clean; 121 unit tests pass. No behavior change beyond the field now appearing in responses.