### PR TITLE
perf(api): revert get_actions filters to scoring context (undo filter-context query-cache cost)

### DIFF
--- a/src/api/routes/v2-history/get_actions/functions.ts
+++ b/src/api/routes/v2-history/get_actions/functions.ts
@@ -26,20 +26,19 @@ export function processMultiVars(queryStruct, parts, field) {
     });
 
     if (must.length > 1) {
-        (queryStruct.bool.filter ??= []).push({
+        queryStruct.bool.must.push({
             bool: {
                 should: must.map(elem => {
                     const _q = {};
                     _q[field] = elem;
                     return {term: _q}
-                }),
-                minimum_should_match: 1
+                })
             }
         });
     } else if (must.length === 1) {
         const mustQuery = {};
         mustQuery[field] = must[0];
-        (queryStruct.bool.filter ??= []).push({term: mustQuery});
+        queryStruct.bool.must.push({term: mustQuery});
     }
 
     if (mustNot.length > 1) {
@@ -66,7 +65,7 @@ function addRangeQuery(queryStruct, prop, pkey, query) {
         "gte": parts[0],
         "lte": parts[1]
     };
-    (queryStruct.bool.filter ??= []).push({range: _termQuery});
+    queryStruct.bool.must.push({range: _termQuery});
 }
 
 // A bound is a block number when it is a bare positive integer; any other value
@@ -183,7 +182,7 @@ export function applyGenericFilters(query, queryStruct, allowedExtraParams: Set<
                                 andParts.forEach(value => {
                                     const _q = {};
                                     _q[pkey] = value;
-                                    (queryStruct.bool.filter ??= []).push({term: _q});
+                                    queryStruct.bool.must.push({term: _q});
                                 });
                             } else {
                                 if (parts[0].startsWith("!")) {
@@ -191,7 +190,7 @@ export function applyGenericFilters(query, queryStruct, allowedExtraParams: Set<
                                     queryStruct.bool.must_not.push({term: _qObj});
                                 } else {
                                     _qObj[pkey] = parts[0];
-                                    (queryStruct.bool.filter ??= []).push({term: _qObj});
+                                    queryStruct.bool.must.push({term: _qObj});
                                 }
                             }
                         }
@@ -234,9 +233,8 @@ export function applyCodeActionFilters(query, queryStruct) {
             }
         }
         if (filterObj.length > 0) {
-            // Code:name filter in filter context (was a scoring root-level should+msm). Semantics
-            // are identical — "match >= 1 of the code:name pairs" — minus the wasted scoring.
-            (queryStruct.bool.filter ??= []).push({bool: {should: filterObj, minimum_should_match: 1}});
+            queryStruct.bool['should'] = filterObj;
+            queryStruct.bool['minimum_should_match'] = 1;
         }
     }
 }
@@ -313,10 +311,11 @@ export function getSortDir(query, maxAscWindowDays = 90) {
 
 export function applyAccountFilters(query, queryStruct) {
     if (query.account) {
-        // Filter context: the account match is a pure include and results are sorted by
-        // global_sequence (never _score), so scoring this should-clause across millions of docs
-        // is wasted work. filter context skips scoring and is cacheable. minimum_should_match is
-        // explicit (a should-only bool defaults to 1, but filter context makes it worth stating).
-        (queryStruct.bool.filter ??= []).push({bool: {should: makeShouldArray(query), minimum_should_match: 1}});
+        // Scoring (must) context, NOT filter. Filter context routes this clause through ES's query
+        // cache; for a low-selectivity account like eosio.token over large/old (cold-tier) segments,
+        // *building* the cached bitset (full per-segment bulkScorer enumeration) costs far more than
+        // the BM25 it would save and defeats index-sort early termination. Observed dominating
+        // node-6 hot_threads (IndicesQueryCache.bulkScorer). See memory: filter-context-query-cache-tradeoff.
+        queryStruct.bool.must.push({"bool": {should: makeShouldArray(query)}});
     }
 }

--- a/tests/unit/filter-context.test.ts
+++ b/tests/unit/filter-context.test.ts
@@ -5,21 +5,23 @@ import {
     applyCodeActionFilters
 } from '../../src/api/routes/v2-history/get_actions/functions.js';
 
-// get_actions builds its query with these clauses in *filter* context (not must/should), because
-// results are always sorted by global_sequence and never by _score — so scoring is wasted work.
-// These tests pin that placement so a regression back to scoring context is caught.
+// get_actions builds its term clauses in *scoring* (must / root-should) context, NOT bool.filter.
+// Filter context routes clauses through ES's query cache; for a low-selectivity account like
+// eosio.token over large/old (cold-tier) segments, building the cached bitset costs far more than
+// the BM25 it saves and defeats index-sort early termination (observed dominating node-6
+// hot_threads). These tests pin the scoring-context placement so it can't regress back to filter.
+// See memory: filter-context-query-cache-tradeoff.
 
 const newQueryStruct = () => ({ bool: { must: [] as any[], must_not: [] as any[], boost: 1.0 } });
 
-describe('applyAccountFilters — filter context', () => {
-    it('puts the account should-array in bool.filter with minimum_should_match, not bool.must', () => {
+describe('applyAccountFilters — scoring context', () => {
+    it('puts the account should-array in bool.must, not bool.filter', () => {
         const qs = newQueryStruct();
         applyAccountFilters({ account: 'eosio.token' }, qs);
 
-        expect(qs.bool.must).toHaveLength(0);
-        expect(qs.bool.filter).toHaveLength(1);
-        const clause = qs.bool.filter[0];
-        expect(clause.bool.minimum_should_match).toBe(1);
+        expect(qs.bool.filter).toBeUndefined();
+        expect(qs.bool.must).toHaveLength(1);
+        const clause = qs.bool.must[0];
         // notified, receipts.receiver, act.authorization.actor — all bound to the account
         expect(clause.bool.should).toEqual([
             { term: { notified: 'eosio.token' } },
@@ -31,61 +33,56 @@ describe('applyAccountFilters — filter context', () => {
     it('is a no-op when no account is given', () => {
         const qs = newQueryStruct();
         applyAccountFilters({}, qs);
-        expect(qs.bool.filter).toBeUndefined();
         expect(qs.bool.must).toHaveLength(0);
+        expect(qs.bool.filter).toBeUndefined();
     });
 });
 
-describe('applyGenericFilters — filter context', () => {
-    it('puts a single primary-term match in bool.filter', () => {
+describe('applyGenericFilters — scoring context', () => {
+    it('puts a single primary-term match in bool.must', () => {
         const qs = newQueryStruct();
         applyGenericFilters({ producer: 'eosio' }, qs, new Set());
-        expect(qs.bool.must).toHaveLength(0);
-        expect(qs.bool.filter).toEqual([{ term: { producer: 'eosio' } }]);
+        expect(qs.bool.filter).toBeUndefined();
+        expect(qs.bool.must).toEqual([{ term: { producer: 'eosio' } }]);
     });
 
-    it('puts a comma multi-value clause in bool.filter as a should with minimum_should_match', () => {
+    it('puts a comma multi-value clause in bool.must as a should group', () => {
         const qs = newQueryStruct();
         applyGenericFilters({ producer: 'a,b' }, qs, new Set());
-        expect(qs.bool.must).toHaveLength(0);
-        expect(qs.bool.filter).toHaveLength(1);
-        expect(qs.bool.filter[0].bool.minimum_should_match).toBe(1);
-        expect(qs.bool.filter[0].bool.should).toEqual([
+        expect(qs.bool.filter).toBeUndefined();
+        expect(qs.bool.must).toHaveLength(1);
+        expect(qs.bool.must[0].bool.should).toEqual([
             { term: { producer: 'a' } },
             { term: { producer: 'b' } }
         ]);
     });
 
-    it('puts a range clause in bool.filter', () => {
+    it('puts a range clause in bool.must', () => {
         const qs = newQueryStruct();
         applyGenericFilters({ block_num: '100-200' }, qs, new Set());
-        expect(qs.bool.must).toHaveLength(0);
-        expect(qs.bool.filter).toEqual([{ range: { block_num: { gte: '100', lte: '200' } } }]);
+        expect(qs.bool.must).toEqual([{ range: { block_num: { gte: '100', lte: '200' } } }]);
     });
 
-    it('keeps negation in must_not (unchanged)', () => {
+    it('keeps negation in must_not', () => {
         const qs = newQueryStruct();
         applyGenericFilters({ producer: '!eosio' }, qs, new Set());
         expect(qs.bool.must_not).toEqual([{ term: { producer: 'eosio' } }]);
-        expect(qs.bool.filter).toBeUndefined();
     });
 
     it('keeps the @transfer.memo full-text match in must so sortedBy=_score still ranks by relevance', () => {
         const qs = newQueryStruct();
         applyGenericFilters({ 'transfer.memo': 'hello' }, qs, new Set(['transfer']));
         expect(qs.bool.must).toEqual([{ match: { '@transfer.memo': { query: 'hello' } } }]);
-        expect(qs.bool.filter).toBeUndefined();
     });
 });
 
-describe('applyCodeActionFilters — filter context', () => {
-    it('puts the code:name filter in bool.filter (not root-level should)', () => {
+describe('applyCodeActionFilters — scoring context', () => {
+    it('puts the code:name filter in a root-level should + minimum_should_match', () => {
         const qs = newQueryStruct();
         applyCodeActionFilters({ filter: 'eosio.token:transfer' }, qs);
-        expect((qs.bool as any).should).toBeUndefined();
-        expect(qs.bool.filter).toHaveLength(1);
-        expect(qs.bool.filter[0].bool.minimum_should_match).toBe(1);
-        expect(qs.bool.filter[0].bool.should).toEqual([
+        expect(qs.bool.filter).toBeUndefined();
+        expect((qs.bool as any).minimum_should_match).toBe(1);
+        expect((qs.bool as any).should).toEqual([
             { bool: { must: [{ term: { 'act.account': 'eosio.token' } }, { term: { 'act.name': 'transfer' } }] } }
         ]);
     });


### PR DESCRIPTION
## Why

Reverts the "Tier-1" filter-context change from #176. During the WAX cold-tier incident, node-6 `hot_threads` showed `IndicesQueryCache$CachingWeightWrapper.bulkScorer` → `LRUQueryCache…bulkScorer` → `TermQuery…seekExact` dominating CPU. That's the **query cache building bitsets for the filter-context term clauses**: for a low-selectivity account (`eosio.token`) over large/old **cold-tier** segments, *constructing* the cached bitset (full per-segment enumeration) costs far more than the BM25 scoring it was meant to save, and it defeats index-sort early termination. Scoring (`must`) clauses are never query-cached, so moving back avoids that path.

## What

- `applyAccountFilters`, `applyGenericFilters` (terms + generic range), `applyCodeActionFilters` → back to `must` / root `should`+`minimum_should_match` (scoring context).
- `must_not` and the `@transfer.memo` match were already scoring-context (unchanged).
- `applyTimeFilter` ranges stay in **filter** context (range/`can_match` shard pruning — not the culprit).
- Tests updated to pin scoring-context placement.

## Scope / honesty

This removes the per-query **amplification** only. The underlying cold-tier load — a client walking old history via REST `get_actions` since ~May 25 — **predates** this change and is not fixed by it. Root fix still needs the offending query pattern/client identified (busy-window slowlog + access log) and bounded (rate-limit, or a guard keeping deep/old account queries off cold). hot-first (#176) already keeps the common `eosio.token` top-100 polls on the hot tier.

## Testing
`tsc --noEmit` clean; `bun test tests/unit` → 121 pass.
