### PR TITLE
perf(api): recent-first routing for get_transaction (default off)

### DIFF
--- a/references/config.ref.json
+++ b/references/config.ref.json
@@ -41,6 +41,7 @@
     "tx_cache_expiration_sec": 3600,
     "hot_first_actions": false,
     "hot_first_window": 2,
+    "hot_first_transaction": false,
     "v1_chain_cache": [
       {"path": "get_block","ttl": 3000},
       {"path": "get_info","ttl": 500}

--- a/src/api/routes/v2-history/get_transaction/get_transaction.ts
+++ b/src/api/routes/v2-history/get_transaction/get_transaction.ts
@@ -102,6 +102,16 @@ async function getTransaction(fastify: FastifyInstance, request: FastifyRequest)
             size: _size,
             query: {bool: {must: [{term: {trx_id: trxId}}]}},
             sort: {global_sequence: "asc"}
+        }).catch((err: any) => {
+            // Without a block_hint a 404 just means the probed index set isn't present yet (e.g. a
+            // hot window that resolved to a not-yet-created name, or a freshly provisioned chain).
+            // Treat it as a miss so we fall back to the full pattern instead of surfacing the
+            // (here misleading) "no data near block_hint" error. With a block_hint the 404 is real
+            // and is handled by the outer catch below.
+            if (err?.meta?.statusCode === 404 && !blockHint) {
+                return {hits: {hits: []}};
+            }
+            throw err;
         });
 
         let pResults;
@@ -111,13 +121,15 @@ async function getTransaction(fastify: FastifyInstance, request: FastifyRequest)
         } catch (e: any) {
             console.log(e.message);
             if (e?.meta?.statusCode === 404) {
+                // Only reachable with a block_hint now (see runSearch catch), so the message fits.
                 response.error = 'no data near block_hint'
                 return response;
             }
             throw e;
         }
         hits = pResults[1].hits.hits;
-        response.lib = pResults[0].last_irreversible_block_num;
+        // $getInfo resolves null on failure — don't turn a recoverable lib-lookup miss into a 500.
+        response.lib = pResults[0]?.last_irreversible_block_num;
 
         // Recent-first miss: the trx isn't in the hot window, so widen to the full set — the only
         // path that can reach cold shards. A non-empty hit set is already complete (single partition).

--- a/src/api/routes/v2-history/get_transaction/get_transaction.ts
+++ b/src/api/routes/v2-history/get_transaction/get_transaction.ts
@@ -1,5 +1,6 @@
 import {FastifyInstance, FastifyReply, FastifyRequest} from "fastify";
 import {mergeActionMeta, timedQuery} from "../../../helpers/functions.js";
+import {resolveHotIndices} from "../../../helpers/hot-index.js";
 import {regroupActions} from "../../../helpers/regroup-actions.js";
 import {API} from "@wharfkit/antelope";
 
@@ -71,35 +72,59 @@ async function getTransaction(fastify: FastifyInstance, request: FastifyRequest)
     if (!hits) {
         const _size = conf.api.limits.get_trx_actions || 100;
         const blockHint = parseInt(query.block_hint, 10);
-        let indexPattern = '';
+        const fullPattern = fastify.manager.chain + '-action-*';
+
+        // Resolve the index target. A block_hint pins the single partition (no fan-out). Without one,
+        // a trx_id term query has no block range to prune on, so it fans out across EVERY action
+        // partition — including cold-tier shards holding old history (the dominant cold-node CPU
+        // sink observed on the WAX cluster). All of a transaction's documents share one block, hence
+        // one partition, so a recent-first probe is exact: if the hot window returns any hit it
+        // returns them all, and only a miss (older or non-existent trx) needs to widen to the full
+        // set. Opt-in via api.hot_first_transaction; reuses hot_first_window. See memory:
+        // filter-context-query-cache-tradeoff / stream-replay-cold-tier-hardening.
+        let indexPattern: string;
+        let recentFirst = false;
         if (blockHint) {
             const idxPart = Math.ceil(blockHint / conf.settings.index_partition_size).toString().padStart(6, '0');
             indexPattern = fastify.manager.chain + `-action-${conf.settings.index_version}-${idxPart}`;
+        } else if (conf.api.hot_first_transaction === true) {
+            const hotWindow = conf.api.hot_first_window ?? 2;
+            indexPattern = await resolveHotIndices(fastify, 'action', hotWindow);
+            // Only a recent-first probe if the resolver actually narrowed to the hot window; a
+            // degrade to the wildcard means this first search is already the full set.
+            recentFirst = indexPattern !== fullPattern;
         } else {
-            indexPattern = fastify.manager.chain + '-action-*';
+            indexPattern = fullPattern;
         }
+
+        const runSearch = (index: string) => fastify.elastic.search<any>({
+            index,
+            size: _size,
+            query: {bool: {must: [{term: {trx_id: trxId}}]}},
+            sort: {global_sequence: "asc"}
+        });
+
         let pResults;
         try {
-
-            // build search request
-            const $search = fastify.elastic.search<any>({
-                index: indexPattern,
-                size: _size,
-                query: {bool: {must: [{term: {trx_id: trxId}}]}},
-                sort: {global_sequence: "asc"}
-            });
-
-            // execute in parallel
-            pResults = await Promise.all([$getInfo, $search]);
+            // execute get_info and the (phase-1) search in parallel
+            pResults = await Promise.all([$getInfo, runSearch(indexPattern)]);
         } catch (e: any) {
             console.log(e.message);
-            if (e.meta.statusCode === 404) {
+            if (e?.meta?.statusCode === 404) {
                 response.error = 'no data near block_hint'
                 return response;
             }
+            throw e;
         }
         hits = pResults[1].hits.hits;
         response.lib = pResults[0].last_irreversible_block_num;
+
+        // Recent-first miss: the trx isn't in the hot window, so widen to the full set — the only
+        // path that can reach cold shards. A non-empty hit set is already complete (single partition).
+        if (recentFirst && hits.length === 0) {
+            const widened = await runSearch(fullPattern);
+            hits = widened.hits.hits;
+        }
     }
 
     if (hits.length > 0) {

--- a/src/interfaces/hyperionConfig.ts
+++ b/src/interfaces/hyperionConfig.ts
@@ -175,6 +175,12 @@ interface ApiConfigs {
     // hits — so heavy polling never fans out to old/warm shards. Default off.
     hot_first_actions?: boolean;
     hot_first_window?: number;        // number of newest action partitions in the hot window, default: 2
+    // Recent-first routing for get_transaction. Without a block_hint, a trx_id lookup has no block
+    // range to prune on and fans out across EVERY action partition (cold tier included). All of a
+    // transaction's documents share one block (one partition), so the hot window is probed first and
+    // the full <chain>-action-* set is queried only on a miss (older/non-existent trx). Reuses
+    // hot_first_window. Default off.
+    hot_first_transaction?: boolean;
 }
 
 interface ExplorerConfigs {
@@ -334,6 +340,7 @@ export const HyperionApiConfigSchema = z.object({
     max_asc_window_days: z.number().optional(),
     hot_first_actions: z.boolean().optional(),
     hot_first_window: z.number().optional(),
+    hot_first_transaction: z.boolean().optional(),
 });
 
 // Zod schema for tiered index allocation settings


### PR DESCRIPTION
## Problem

Without a `block_hint`, `get_transaction` runs a `term: trx_id` query against `<chain>-action-*` — every action partition, including older/cold-tier shards. A `trx_id` term carries no block range, so `can_match` cannot prune any shard: each one pays a term-dictionary `seekExact` (plus a decompress on older-codec segments). A steady stream of distinct trx_id lookups (no cache reuse) therefore loads the cold tier disproportionately.

## Fix

All of a transaction's action documents share a single block, hence a single **partition**. So a recent-first probe is exact:

1. Search the hot window first (`resolveHotIndices`, reusing `hot_first_window`).
2. A non-empty result is already **complete** — return it (older tiers never touched).
3. Only on a **miss** (an older or non-existent trx) widen to the full `<chain>-action-*` set.

Looking up a recent transaction never fans out to old shards. A `block_hint` still pins its single partition as before.

## Safety

- **Opt-in** via `api.hot_first_transaction` (default `false`); behaviour-preserving when disabled.
- **Correctness is unconditional**: single-partition-per-trx guarantees a hot-window hit set is whole, and the widen-on-miss fallback covers everything else. If the resolver degrades to the wildcard, phase 1 is already the full search (no redundant query).
- Residual: lookups for transactions older than the hot window (or non-existent ids) still widen to the full set on each miss; recent-first only optimizes the recent-lookup path.

## Also

- Propagate non-404 ES errors instead of dereferencing an undefined result (previously a non-404 error fell through to `pResults[1]` → `TypeError`).
- Guard the 404 check with optional chaining (`e?.meta?.statusCode`).

## Testing

- `tsc --noEmit` clean.
- `bun test tests/unit/` — 121 pass (config validation accepts the new key; `resolveHotIndices` already covered by `hot-index.test.ts`).

## Ops

Enable with:
```json
"hot_first_transaction": true,
"hot_first_window": 2
```