### PR TITLE
feat(api): opt-in profiling for get_transaction recent-first

### DIFF
--- a/references/config.ref.json
+++ b/references/config.ref.json
@@ -42,6 +42,7 @@
     "hot_first_actions": false,
     "hot_first_window": 2,
     "hot_first_transaction": false,
+    "hot_first_transaction_profiling": false,
     "v1_chain_cache": [
       {"path": "get_block","ttl": 3000},
       {"path": "get_info","ttl": 500}

--- a/src/api/routes/v2-history/get_transaction/get_transaction.ts
+++ b/src/api/routes/v2-history/get_transaction/get_transaction.ts
@@ -76,13 +76,11 @@ async function getTransaction(fastify: FastifyInstance, request: FastifyRequest)
         const fullPattern = fastify.manager.chain + '-action-*';
 
         // Resolve the index target. A block_hint pins the single partition (no fan-out). Without one,
-        // a trx_id term query has no block range to prune on, so it fans out across EVERY action
-        // partition — including cold-tier shards holding old history (the dominant cold-node CPU
-        // sink observed on the WAX cluster). All of a transaction's documents share one block, hence
-        // one partition, so a recent-first probe is exact: if the hot window returns any hit it
-        // returns them all, and only a miss (older or non-existent trx) needs to widen to the full
-        // set. Opt-in via api.hot_first_transaction; reuses hot_first_window. See memory:
-        // filter-context-query-cache-tradeoff / stream-replay-cold-tier-hardening.
+        // a trx_id term query has no block range to prune on, so it fans out across every action
+        // partition, including older/cold-tier shards. All of a transaction's documents share one
+        // block, hence one partition, so a recent-first probe is exact: if the hot window returns any
+        // hit it returns them all, and only a miss (older or non-existent trx) needs to widen to the
+        // full set. Opt-in via api.hot_first_transaction; reuses hot_first_window.
         let indexPattern: string;
         let recentFirst = false;
         if (blockHint) {
@@ -161,10 +159,15 @@ async function getTransaction(fastify: FastifyInstance, request: FastifyRequest)
                 const bn = h?._source?.block_num ?? 0;
                 if (bn > foundBlock) foundBlock = bn;
             }
-            const headBlock = Number(pResults[0]?.head_block_num ?? 0);
+            // head_block_num is a Wharfkit UInt32 (fresh from get_info) or a plain number (from the
+            // redis cache); unwrap .value when present before coercing.
+            const headRaw: any = pResults[0]?.head_block_num;
+            const headBlock = Number(headRaw?.value ?? headRaw ?? 0);
             const foundPart = foundBlock ? Math.ceil(foundBlock / partSize) : 0;
             const headPart = headBlock ? Math.ceil(headBlock / partSize) : 0;
-            const partsBack = (foundPart && headPart) ? (headPart - foundPart) : -1;
+            // Clamp: ES/get_info micro-lag can place a hit one block past the reported head, which
+            // would yield a negative value and collide with the -1 "not found" sentinel.
+            const partsBack = (foundPart && headPart) ? Math.max(0, headPart - foundPart) : -1;
             const served = recentFirst ? (widened ? 'full' : 'hot') : 'full';
             hLog(`[gtx-profile] trx=${trxId.slice(0, 12)} served=${served} hot_hits=${phase1Hits} ` +
                 `found_block=${foundBlock || 'none'} found_part=${foundPart || '-'} head_part=${headPart || '-'} ` +

--- a/src/api/routes/v2-history/get_transaction/get_transaction.ts
+++ b/src/api/routes/v2-history/get_transaction/get_transaction.ts
@@ -1,6 +1,7 @@
 import {FastifyInstance, FastifyReply, FastifyRequest} from "fastify";
 import {mergeActionMeta, timedQuery} from "../../../helpers/functions.js";
 import {resolveHotIndices} from "../../../helpers/hot-index.js";
+import {hLog} from "../../../../indexer/helpers/common_functions.js";
 import {regroupActions} from "../../../helpers/regroup-actions.js";
 import {API} from "@wharfkit/antelope";
 
@@ -114,6 +115,11 @@ async function getTransaction(fastify: FastifyInstance, request: FastifyRequest)
             throw err;
         });
 
+        // Opt-in diagnostic (api.hot_first_transaction_profiling): only for the no-block_hint path,
+        // where the fan-out happens. Times each phase and records how far back the trx actually was.
+        const profile = conf.api.hot_first_transaction_profiling === true && !blockHint;
+        const tStart = profile ? Date.now() : 0;
+
         let pResults;
         try {
             // execute get_info and the (phase-1) search in parallel
@@ -131,11 +137,38 @@ async function getTransaction(fastify: FastifyInstance, request: FastifyRequest)
         // $getInfo resolves null on failure — don't turn a recoverable lib-lookup miss into a 500.
         response.lib = pResults[0]?.last_irreversible_block_num;
 
+        const phase1Ms = profile ? Date.now() - tStart : 0;
+        const phase1Hits = hits.length;
+        let widenMs = 0;
+        let widened = false;
+
         // Recent-first miss: the trx isn't in the hot window, so widen to the full set — the only
         // path that can reach cold shards. A non-empty hit set is already complete (single partition).
         if (recentFirst && hits.length === 0) {
-            const widened = await runSearch(fullPattern);
-            hits = widened.hits.hits;
+            const tWiden = profile ? Date.now() : 0;
+            const widenedRes = await runSearch(fullPattern);
+            hits = widenedRes.hits.hits;
+            widenMs = profile ? Date.now() - tWiden : 0;
+            widened = true;
+        }
+
+        if (profile) {
+            // parts_back = how many partitions older than head the trx is; a hot_first_window of
+            // (parts_back + 1) would have served this lookup from the hot path. -1 = not found.
+            const partSize = conf.settings.index_partition_size;
+            let foundBlock = 0;
+            for (const h of hits) {
+                const bn = h?._source?.block_num ?? 0;
+                if (bn > foundBlock) foundBlock = bn;
+            }
+            const headBlock = Number(pResults[0]?.head_block_num ?? 0);
+            const foundPart = foundBlock ? Math.ceil(foundBlock / partSize) : 0;
+            const headPart = headBlock ? Math.ceil(headBlock / partSize) : 0;
+            const partsBack = (foundPart && headPart) ? (headPart - foundPart) : -1;
+            const served = recentFirst ? (widened ? 'full' : 'hot') : 'full';
+            hLog(`[gtx-profile] trx=${trxId.slice(0, 12)} served=${served} hot_hits=${phase1Hits} ` +
+                `found_block=${foundBlock || 'none'} found_part=${foundPart || '-'} head_part=${headPart || '-'} ` +
+                `parts_back=${partsBack} phase1_ms=${phase1Ms} widen_ms=${widenMs} total_ms=${phase1Ms + widenMs}`);
         }
     }
 

--- a/src/interfaces/hyperionConfig.ts
+++ b/src/interfaces/hyperionConfig.ts
@@ -181,6 +181,12 @@ interface ApiConfigs {
     // the full <chain>-action-* set is queried only on a miss (older/non-existent trx). Reuses
     // hot_first_window. Default off.
     hot_first_transaction?: boolean;
+    // Diagnostic: when true, log one line per get_transaction served WITHOUT a block_hint —
+    // which phase served it (hot vs widened), per-phase timings, and how many partitions back the
+    // trx actually was (`parts_back`). Aggregating parts_back reveals the block-age distribution of
+    // lookups, i.e. the hot_first_window that would capture a given fraction of them. Default off;
+    // noisy under load (one line per request) — enable briefly to sample, then disable.
+    hot_first_transaction_profiling?: boolean;
 }
 
 interface ExplorerConfigs {
@@ -341,6 +347,7 @@ export const HyperionApiConfigSchema = z.object({
     hot_first_actions: z.boolean().optional(),
     hot_first_window: z.number().optional(),
     hot_first_transaction: z.boolean().optional(),
+    hot_first_transaction_profiling: z.boolean().optional(),
 });
 
 // Zod schema for tiered index allocation settings


### PR DESCRIPTION
## Summary

Adds an opt-in diagnostic, `api.hot_first_transaction_profiling` (default `false`), that instruments the `get_transaction` recent-first path (PR #180) so operators can size `hot_first_window` from data instead of guessing.

A `get_transaction` issued **without** a `block_hint` has no block range to prune on, so it fans out across every action partition. The recent-first option (`hot_first_transaction`) probes the newest `hot_first_window` partitions first and widens to the full set only on a miss. Whether a given window captures most lookups depends on how far back the requested transactions actually are — which this profiling measures.

## Behaviour

When enabled, logs one line per `get_transaction` served without a `block_hint`:

```
[gtx-profile] trx=<id12> served=hot|full hot_hits=N found_block=B found_part=P head_part=H parts_back=K phase1_ms=.. widen_ms=.. total_ms=..
```

- `served` — `hot` (answered from the hot window) or `full` (widened, or recent-first disabled).
- `parts_back` — partitions older than head the transaction was found in. A `hot_first_window` of `parts_back + 1` would have served it from the hot path. `-1` = not found.
- `phase1_ms` / `widen_ms` / `total_ms` — per-phase Elasticsearch timing.

Aggregating `parts_back` over a sample shows the block-age distribution of lookups, indicating whether increasing `hot_first_window` would help or whether the requests are spread across history.

## Notes

- No behaviour change when disabled. When enabled it adds only a few `Date.now()` calls and one log line per request, but it logs **one line per request** — intended to be enabled briefly to sample, then disabled.
- `tsc --noEmit` clean; config-validation unit test passes.

## Usage

```json
"hot_first_transaction": true,
"hot_first_transaction_profiling": true
```
After sampling:
```
grep gtx-profile <log> | grep -oE 'parts_back=[0-9-]+' | sort | uniq -c | sort -rn
```