### PR TITLE
feat(api): accept global_sequence/block_num range as a sort=asc bound + require_bounded_asc toggle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,11 @@
 
 ### New Config Options
 
+One new optional field in the `api` section of the chain config:
+
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| `require_bounded_asc` | `boolean` | `true` | When `false`, disables the `sort=asc` bound requirement (and the `max_asc_window_days` window check) on `get_actions` (v1 & v2). For self-hosted operators who accept the performance cost of unbounded ascending scans on their own infrastructure. |
+| `api.require_bounded_asc` | `boolean` | `true` | When `false`, disables the `sort=asc` bound requirement (and the `max_asc_window_days` window check) on `get_actions` (v1 & v2). For self-hosted operators who accept the performance cost of unbounded ascending scans on their own infrastructure. |
 
 ### Behavior Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## 4.1.0 (unreleased)
+
+### Improvements
+
+*   **`sort=asc` now accepts a `global_sequence` (or `block_num`) range as a valid bound** on `get_actions` (v2). Previously only `after`/`before` (ISO date or block number) satisfied the bound requirement, so a request like `get_actions?account=X&global_sequence=<from>-<to>&sort=asc` was rejected as unbounded even though the range already constrains the scan. Because `global_sequence` is the default sort field, such a range bounds the candidate set directly — there is no full-index reverse scan to guard against. Bare positive `global_sequence`/`block_num` values are accepted too; `0` and non-numeric input are not.
+
+### New Config Options
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `require_bounded_asc` | `boolean` | `true` | When `false`, disables the `sort=asc` bound requirement (and the `max_asc_window_days` window check) on `get_actions` (v1 & v2). For self-hosted operators who accept the performance cost of unbounded ascending scans on their own infrastructure. |
+
+### Behavior Changes
+
+*   `sort=asc` on `get_actions` (v2) is satisfied by **any** of: a valid `after`/`before`, or a `global_sequence`/`block_num` range/value.
+*   Setting `api.require_bounded_asc: false` makes `sort=asc` behave as it did before the v4.0.3 guard — no bound required, no window cap. The guard remains **on by default**.
+
 ## 4.0.8 (2026-06-02)
 
 ### Fixes

--- a/src/api/routes/v1-history/get_actions/get_actions.ts
+++ b/src/api/routes/v1-history/get_actions/get_actions.ts
@@ -197,25 +197,28 @@ async function getActions(fastify: FastifyInstance, request: FastifyRequest) {
     }
 
     const maxAscWindowDays = fastify.manager.config.api.max_asc_window_days || 90;
+    const requireBoundedAsc = fastify.manager.config.api.require_bounded_asc !== false;
 
     if (reqBody.sort) {
         if (reqBody.sort === 'asc' || reqBody.sort === '1') {
-            // sort=asc requires a valid, recent time range to prevent full-index reverse scans
-            const after = reqBody.after;
-            const before = reqBody.before;
-            const isValidBound = (v) => v && (!isNaN(new Date(v).getTime()) || (Number.isInteger(Number(v)) && Number(v) > 0));
-            if (!isValidBound(after) && !isValidBound(before)) {
-                return {error: 'sort=asc requires a valid "after" or "before" (ISO date or block number) to bound the search'};
-            }
-            // Apply the recency window to a *date* "after" bound. Block-number bounds are
-            // exempt. Classified the same way as the range filter below so a date without
-            // a 'T' (e.g. "2026-01-01", or "0" which parses to year 2000) cannot slip past.
-            if (after && !isBlockNumber(after)) {
-                const afterDate = new Date(after);
-                if (!isNaN(afterDate.getTime())) {
-                    const maxAge = Date.now() - (maxAscWindowDays * 86400000);
-                    if (afterDate.getTime() < maxAge) {
-                        return {error: `sort=asc "after" date must be within the last ${maxAscWindowDays} days — use block numbers for "after"/"before" to query older ranges`};
+            if (requireBoundedAsc) {
+                // sort=asc requires a valid, recent time range to prevent full-index reverse scans
+                const after = reqBody.after;
+                const before = reqBody.before;
+                const isValidBound = (v) => v && (!isNaN(new Date(v).getTime()) || (Number.isInteger(Number(v)) && Number(v) > 0));
+                if (!isValidBound(after) && !isValidBound(before)) {
+                    return {error: 'sort=asc requires a valid "after" or "before" (ISO date or block number) to bound the search'};
+                }
+                // Apply the recency window to a *date* "after" bound. Block-number bounds are
+                // exempt. Classified the same way as the range filter below so a date without
+                // a 'T' (e.g. "2026-01-01", or "0" which parses to year 2000) cannot slip past.
+                if (after && !isBlockNumber(after)) {
+                    const afterDate = new Date(after);
+                    if (!isNaN(afterDate.getTime())) {
+                        const maxAge = Date.now() - (maxAscWindowDays * 86400000);
+                        if (afterDate.getTime() < maxAge) {
+                            return {error: `sort=asc "after" date must be within the last ${maxAscWindowDays} days — use block numbers for "after"/"before" to query older ranges`};
+                        }
                     }
                 }
             }

--- a/src/api/routes/v1-history/get_actions/get_actions.ts
+++ b/src/api/routes/v1-history/get_actions/get_actions.ts
@@ -205,7 +205,7 @@ async function getActions(fastify: FastifyInstance, request: FastifyRequest) {
                 // sort=asc requires a valid, recent time range to prevent full-index reverse scans
                 const after = reqBody.after;
                 const before = reqBody.before;
-                const isValidBound = (v) => v && (!isNaN(new Date(v).getTime()) || (Number.isInteger(Number(v)) && Number(v) > 0));
+                const isValidBound = (v) => (typeof v === 'string' || typeof v === 'number') && v && (!isNaN(new Date(v).getTime()) || (Number.isInteger(Number(v)) && Number(v) > 0));
                 if (!isValidBound(after) && !isValidBound(before)) {
                     return {error: 'sort=asc requires a valid "after" or "before" (ISO date or block number) to bound the search'};
                 }

--- a/src/api/routes/v2-history/get_actions/functions.ts
+++ b/src/api/routes/v2-history/get_actions/functions.ts
@@ -278,11 +278,15 @@ export function getSkipLimit(query: any, max?: number): { skip: number, limit: n
 // A range (or single positive value) on a monotonic field bounds an asc scan as
 // effectively as after/before. global_sequence is the default sort field, so a
 // global_sequence range constrains the candidate set directly; block_num ranges
-// likewise. Accepts "<from>-<to>" ranges and bare positive values; rejects 0 and
-// non-numeric input. Digit-string checks avoid Number() precision loss on uint64.
+// likewise. Accepts "<from>-<to>" ranges and bare positive values. A bare 0 and
+// non-numeric input are rejected; in a range only the *upper* bound must be
+// positive (a 0 lower bound is a valid "from the start" bound). Digit-string
+// checks avoid Number() precision loss on uint64. Array inputs (a query param
+// repeated in the URL) are rejected here and would also break downstream filter
+// building, so they fail fast as unbounded rather than 500 later.
 function hasMonotonicBound(query): boolean {
     const isBoundValue = (v) => {
-        if (v === undefined || v === null) {
+        if (typeof v !== 'string' && typeof v !== 'number') {
             return false;
         }
         const s = String(v).trim();
@@ -308,11 +312,11 @@ export function getSortDir(query, maxAscWindowDays = 90, requireBoundedAsc = tru
                 // sort=asc requires a valid, recent time range to prevent full-index reverse scans
                 const after = query.after;
                 const before = query.before;
-                const isValidBound = (v) => v && (!isNaN(new Date(v).getTime()) || (Number.isInteger(Number(v)) && Number(v) > 0));
+                const isValidBound = (v) => (typeof v === 'string' || typeof v === 'number') && v && (!isNaN(new Date(v).getTime()) || (Number.isInteger(Number(v)) && Number(v) > 0));
                 // A global_sequence/block_num range also bounds the scan — global_sequence is the
                 // default sort field, so such a range constrains the candidate set directly.
                 if (!isValidBound(after) && !isValidBound(before) && !hasMonotonicBound(query)) {
-                    badRequest('sort=asc requires a valid "after"/"before" (ISO date or block number) or a global_sequence/block_num range to bound the search');
+                    badRequest('sort=asc requires a valid "after"/"before" (ISO date or block number) or a global_sequence/block_num range or value to bound the search');
                 }
                 // Apply the recency window to a *date* "after" bound. Block-number bounds are
                 // exempt — they bound the reverse scan just as well. Classified the same way

--- a/src/api/routes/v2-history/get_actions/functions.ts
+++ b/src/api/routes/v2-history/get_actions/functions.ts
@@ -275,27 +275,56 @@ export function getSkipLimit(query: any, max?: number): { skip: number, limit: n
     return {skip, limit};
 }
 
-export function getSortDir(query, maxAscWindowDays = 90) {
+// A range (or single positive value) on a monotonic field bounds an asc scan as
+// effectively as after/before. global_sequence is the default sort field, so a
+// global_sequence range constrains the candidate set directly; block_num ranges
+// likewise. Accepts "<from>-<to>" ranges and bare positive values; rejects 0 and
+// non-numeric input. Digit-string checks avoid Number() precision loss on uint64.
+function hasMonotonicBound(query): boolean {
+    const isBoundValue = (v) => {
+        if (v === undefined || v === null) {
+            return false;
+        }
+        const s = String(v).trim();
+        if (s === '') {
+            return false;
+        }
+        const parts = s.split('-');
+        if (parts.length === 2) {
+            // "<from>-<to>" range — upper bound must be a positive integer
+            return /^\d+$/.test(parts[0]) && /^\d+$/.test(parts[1]) && !/^0+$/.test(parts[1]);
+        }
+        // single positive value (matches at most a handful of docs)
+        return /^\d+$/.test(s) && !/^0+$/.test(s);
+    };
+    return isBoundValue(query.global_sequence) || isBoundValue(query.block_num);
+}
+
+export function getSortDir(query, maxAscWindowDays = 90, requireBoundedAsc = true) {
     let sort_direction = 'desc';
     if (query.sort) {
         if (query.sort === 'asc' || query.sort === '1') {
-            // sort=asc requires a valid, recent time range to prevent full-index reverse scans
-            const after = query.after;
-            const before = query.before;
-            const isValidBound = (v) => v && (!isNaN(new Date(v).getTime()) || (Number.isInteger(Number(v)) && Number(v) > 0));
-            if (!isValidBound(after) && !isValidBound(before)) {
-                badRequest('sort=asc requires a valid "after" or "before" (ISO date or block number) to bound the search');
-            }
-            // Apply the recency window to a *date* "after" bound. Block-number bounds are
-            // exempt — they bound the reverse scan just as well. Classified the same way
-            // as applyTimeFilter so a date without a 'T' (e.g. "2026-01-01", or "0" which
-            // parses to year 2000) cannot slip past the window check.
-            if (after && !isBlockNumber(after)) {
-                const afterDate = new Date(after);
-                if (!isNaN(afterDate.getTime())) {
-                    const maxAge = Date.now() - (maxAscWindowDays * 86400000);
-                    if (afterDate.getTime() < maxAge) {
-                        badRequest(`sort=asc "after" date must be within the last ${maxAscWindowDays} days — use block numbers for "after"/"before" to query older ranges`);
+            if (requireBoundedAsc) {
+                // sort=asc requires a valid, recent time range to prevent full-index reverse scans
+                const after = query.after;
+                const before = query.before;
+                const isValidBound = (v) => v && (!isNaN(new Date(v).getTime()) || (Number.isInteger(Number(v)) && Number(v) > 0));
+                // A global_sequence/block_num range also bounds the scan — global_sequence is the
+                // default sort field, so such a range constrains the candidate set directly.
+                if (!isValidBound(after) && !isValidBound(before) && !hasMonotonicBound(query)) {
+                    badRequest('sort=asc requires a valid "after"/"before" (ISO date or block number) or a global_sequence/block_num range to bound the search');
+                }
+                // Apply the recency window to a *date* "after" bound. Block-number bounds are
+                // exempt — they bound the reverse scan just as well. Classified the same way
+                // as applyTimeFilter so a date without a 'T' (e.g. "2026-01-01", or "0" which
+                // parses to year 2000) cannot slip past the window check.
+                if (after && !isBlockNumber(after)) {
+                    const afterDate = new Date(after);
+                    if (!isNaN(afterDate.getTime())) {
+                        const maxAge = Date.now() - (maxAscWindowDays * 86400000);
+                        if (afterDate.getTime() < maxAge) {
+                            badRequest(`sort=asc "after" date must be within the last ${maxAscWindowDays} days — use block numbers for "after"/"before" to query older ranges`);
+                        }
                     }
                 }
             }

--- a/src/api/routes/v2-history/get_actions/get_actions.ts
+++ b/src/api/routes/v2-history/get_actions/get_actions.ts
@@ -25,7 +25,8 @@ async function getActions(fastify: FastifyInstance, request: FastifyRequest) {
     const {skip, limit} = getSkipLimit(query, maxActions);
 
     const maxAscWindowDays = fastify.manager.config.api.max_asc_window_days || 90;
-    const sort_direction = getSortDir(query, maxAscWindowDays);
+    const requireBoundedAsc = fastify.manager.config.api.require_bounded_asc !== false;
+    const sort_direction = getSortDir(query, maxAscWindowDays, requireBoundedAsc);
 
     applyAccountFilters(query, queryStruct);
 

--- a/src/interfaces/hyperionConfig.ts
+++ b/src/interfaces/hyperionConfig.ts
@@ -169,6 +169,7 @@ interface ApiConfigs {
     explorer?: ExplorerConfigs;
     query_timeout?: string;           // ES search timeout (e.g., "5s"), default: "10s"
     max_asc_window_days?: number;     // max range in days for sort=asc queries, default: 90
+    require_bounded_asc?: boolean;    // require a bound (after/before/global_sequence/block_num range) for sort=asc, default: true
     // Hot-first routing for unbounded latest-N get_actions polls (e.g. account=eosio.token,
     // desc, no time bound). When enabled, the recent action partition(s) are searched first and
     // the full <chain>-action-* set is queried only if that window returns fewer than `limit`
@@ -344,6 +345,7 @@ export const HyperionApiConfigSchema = z.object({
     explorer: ExplorerConfigsSchema.optional(),
     query_timeout: z.string().optional(),
     max_asc_window_days: z.number().optional(),
+    require_bounded_asc: z.boolean().optional(),
     hot_first_actions: z.boolean().optional(),
     hot_first_window: z.number().optional(),
     hot_first_transaction: z.boolean().optional(),

--- a/tests/unit/query-guards.test.ts
+++ b/tests/unit/query-guards.test.ts
@@ -98,6 +98,47 @@ describe('getSortDir', () => {
         const todayDateOnly = new Date(Date.now() - 3600000).toISOString().split('T')[0];
         expect(getSortDir({ sort: 'asc', after: todayDateOnly })).toBe('asc');
     });
+
+    // sort=asc bounded by a global_sequence range (the default sort field)
+    it('should return asc with a global_sequence range bound', () => {
+        expect(getSortDir({ sort: 'asc', global_sequence: '1000-2000' })).toBe('asc');
+    });
+
+    it('should return asc with a single positive global_sequence value', () => {
+        expect(getSortDir({ sort: 'asc', global_sequence: '123456789' })).toBe('asc');
+    });
+
+    it('should return asc with a block_num range bound', () => {
+        expect(getSortDir({ sort: 'asc', block_num: '425000000-425100000' })).toBe('asc');
+    });
+
+    it('should throw for sort=asc with a global_sequence range whose upper bound is 0', () => {
+        expect(() => getSortDir({ sort: 'asc', global_sequence: '0-0' })).toThrow('sort=asc requires');
+    });
+
+    it('should throw for sort=asc with a non-numeric global_sequence', () => {
+        expect(() => getSortDir({ sort: 'asc', global_sequence: 'garbage' })).toThrow('sort=asc requires');
+    });
+
+    it('should still apply the recency window to an old "after" date alongside a global_sequence bound', () => {
+        const oldDate = new Date('2020-01-01T00:00:00Z').toISOString();
+        expect(getSortDir({ sort: 'asc', global_sequence: '1000-2000' })).toBe('asc');
+        expect(() => getSortDir({ sort: 'asc', after: oldDate, global_sequence: '1000-2000' })).toThrow('within the last');
+    });
+
+    // require_bounded_asc = false disables the guard entirely
+    it('should return asc without any bound when requireBoundedAsc is false', () => {
+        expect(getSortDir({ sort: 'asc' }, 90, false)).toBe('asc');
+    });
+
+    it('should skip the max window check when requireBoundedAsc is false', () => {
+        const oldDate = new Date('2020-01-01T00:00:00Z').toISOString();
+        expect(getSortDir({ sort: 'asc', after: oldDate }, 90, false)).toBe('asc');
+    });
+
+    it('should still reject an invalid sort direction when requireBoundedAsc is false', () => {
+        expect(() => getSortDir({ sort: 'invalid' }, 90, false)).toThrow('invalid sort direction');
+    });
 });
 
 describe('applyTimeFilter (mixed date / block-number bounds)', () => {

--- a/tests/unit/query-guards.test.ts
+++ b/tests/unit/query-guards.test.ts
@@ -120,6 +120,18 @@ describe('getSortDir', () => {
         expect(() => getSortDir({ sort: 'asc', global_sequence: 'garbage' })).toThrow('sort=asc requires');
     });
 
+    it('should accept a range with a 0 lower bound (0-2000 is a valid "from start" bound)', () => {
+        expect(getSortDir({ sort: 'asc', global_sequence: '0-2000' })).toBe('asc');
+    });
+
+    it('should reject an array global_sequence (param repeated in the URL)', () => {
+        expect(() => getSortDir({ sort: 'asc', global_sequence: ['1000-2000', '3000-4000'] })).toThrow('sort=asc requires');
+    });
+
+    it('should reject an array after bound (param repeated in the URL)', () => {
+        expect(() => getSortDir({ sort: 'asc', after: ['425000000', '425100000'] })).toThrow('sort=asc requires');
+    });
+
     it('should still apply the recency window to an old "after" date alongside a global_sequence bound', () => {
         const oldDate = new Date('2020-01-01T00:00:00Z').toISOString();
         expect(getSortDir({ sort: 'asc', global_sequence: '1000-2000' })).toBe('asc');


### PR DESCRIPTION
## Summary

`get_actions` with `sort=asc` requires a bound to prevent unbounded full-index reverse scans. Until now only `after`/`before` (ISO date or block number) satisfied that requirement — so an already-bounded query such as:

```
/v2/history/get_actions?account=X&global_sequence=<from>-<to>&limit=1000&sort=asc
```

was rejected as unbounded, even though the `global_sequence` range fully constrains the scan. Since `global_sequence` is the **default sort field**, such a range bounds the candidate set directly; there is no full-index reverse scan to guard against. This pattern is a natural fit for account-history sync flows that page by `global_sequence`.

## Changes

- **`getSortDir` (v2)** now accepts a `global_sequence` or `block_num` range (`<from>-<to>`) — or a bare positive value — as a valid `sort=asc` bound, alongside the existing `after`/`before`. Validation is digit-string based to avoid `Number()` precision loss on `uint64` `global_sequence`; `0` and non-numeric input are rejected. The `after` recency-window check (`max_asc_window_days`) is unchanged and still applies to date bounds.
- **New config `api.require_bounded_asc`** (default `true`). When set to `false`, the `sort=asc` bound requirement **and** the `max_asc_window_days` window check are disabled on both v1 and v2 — for self-hosted operators who accept the performance cost of unbounded ascending scans on their own infrastructure. The guard remains on by default.
- v1 honors the new flag (it does not filter by `global_sequence`, so it does not advertise that as a bound).

## Tests

- 9 new `getSortDir` unit tests (global_sequence/block_num range + value bounds, `0`/garbage rejection, recency-window interaction, `requireBoundedAsc=false`).
- Full unit suite: 130/130 pass. Typecheck clean.

## Docs / follow-up

- CHANGELOG updated under `4.1.0 (unreleased)`.
- Operator-facing docs (`hyperion-docs`) should document `require_bounded_asc` when this lands.