### PR TITLE
fix(health): cache last-indexed-block query to prevent ES search-pool saturation

### DIFF
--- a/src/api/routes/v2/health/health.ts
+++ b/src/api/routes/v2/health/health.ts
@@ -144,6 +144,32 @@ async function checkNodeos(fastify: FastifyInstance): Promise<ServiceResponse<No
     }
 }
 
+/**
+ * Fetch [lastIndexedBlock, totalIndexedBlocks] with a short-TTL Redis cache.
+ *
+ * The underlying getLastIndexedBlockWithTotalBlocks is an ES aggregation that
+ * otherwise runs on EVERY /v2/health call — the one uncached phase in the
+ * health check. Under aggressive health polling (e.g. a load-balancer probe
+ * retry-storm) that saturates the Elasticsearch search pool. A few seconds of
+ * staleness is immaterial for a health probe (chain blocks are ~500ms), so
+ * concurrent probes share one cached result.
+ *
+ * Returns the block pair plus a `cache` flag (true = served from Redis).
+ */
+export async function getCachedLastIndexedBlocks(
+    fastify: FastifyInstance
+): Promise<{ indexedBlocks: [number, number]; cache: boolean }> {
+    const key = `${fastify.manager.chain}::last_indexed_blocks`;
+    const cachedValue = await fastify.redis.get(key);
+    if (cachedValue) {
+        return { indexedBlocks: JSON.parse(cachedValue), cache: true };
+    }
+    const indexedBlocks = await getLastIndexedBlockWithTotalBlocks(fastify.elastic, fastify.manager.chain);
+    // cache for 3 seconds
+    await fastify.redis.set(key, JSON.stringify(indexedBlocks), 'EX', 3);
+    return { indexedBlocks, cache: false };
+}
+
 // Test Elasticsearch connection and indexed range
 async function checkElastic(fastify: FastifyInstance): Promise<ServiceResponse<ESService>> {
     try {
@@ -246,13 +272,17 @@ async function checkElastic(fastify: FastifyInstance): Promise<ServiceResponse<E
         }
 
 
-        // Last indexed block
+        // Last indexed block (short-TTL cached; see getCachedLastIndexedBlocks)
         const tRefElastic3 = process.hrtime.bigint();
-        let indexedBlocks = await getLastIndexedBlockWithTotalBlocks(fastify.elastic, fastify.manager.chain);
+        const lastBlocksResult = await getCachedLastIndexedBlocks(fastify);
+        const indexedBlocks = lastBlocksResult.indexedBlocks;
+        if (lastBlocksResult.cache) {
+            cached = true;
+        }
         times.push({
             phase: 'last_indexed_block',
             phase_time_ms: Number(process.hrtime.bigint() - tRefElastic3) / 1000000,
-            cache: false
+            cache: lastBlocksResult.cache
         });
 
         // Calculate missing blocks

--- a/tests/unit/health-cache.test.ts
+++ b/tests/unit/health-cache.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect } from 'bun:test';
+import { getCachedLastIndexedBlocks } from '../../src/api/routes/v2/health/health.js';
+
+// Minimal in-memory Redis stub with TTL-agnostic get/set that records calls.
+function makeRedisStub(initial: Record<string, string> = {}) {
+    const store: Record<string, string> = { ...initial };
+    const calls = { get: 0, set: 0 };
+    return {
+        store,
+        calls,
+        get: async (key: string) => {
+            calls.get++;
+            return store[key] ?? null;
+        },
+        set: async (key: string, value: string, ..._args: any[]) => {
+            calls.set++;
+            store[key] = value;
+            return 'OK';
+        }
+    };
+}
+
+// fastify.elastic is only reached through getLastIndexedBlockWithTotalBlocks,
+// which issues a single search on `${chain}-block-*`. We stub that search and
+// count invocations to prove the cache actually spares Elasticsearch.
+function makeElasticStub(lastBlock: number, totalBlocks: number) {
+    const calls = { search: 0 };
+    const client = {
+        calls,
+        search: async (_params: any) => {
+            calls.search++;
+            return {
+                hits: {
+                    total: { value: totalBlocks },
+                    hits: [{ sort: [lastBlock] }]
+                }
+            };
+        }
+    };
+    return client;
+}
+
+function makeFastify(redis: any, elastic: any, chain = 'testchain') {
+    return { redis, elastic, manager: { chain } } as any;
+}
+
+describe('getCachedLastIndexedBlocks', () => {
+    it('cache miss: queries Elasticsearch, writes to Redis, reports cache=false', async () => {
+        const redis = makeRedisStub();
+        const elastic = makeElasticStub(1000, 950);
+        const fastify = makeFastify(redis, elastic);
+
+        const result = await getCachedLastIndexedBlocks(fastify);
+
+        expect(result.cache).toBe(false);
+        expect(result.indexedBlocks[0]).toBe(1000);
+        expect(elastic.calls.search).toBe(1);
+        // value was cached under the chain-scoped key
+        expect(redis.store['testchain::last_indexed_blocks']).toBe(JSON.stringify([1000, 950]));
+        expect(redis.calls.set).toBe(1);
+    });
+
+    it('cache hit: serves from Redis, does NOT touch Elasticsearch, reports cache=true', async () => {
+        const redis = makeRedisStub({
+            'testchain::last_indexed_blocks': JSON.stringify([2000, 1980])
+        });
+        const elastic = makeElasticStub(9999, 9999);
+        const fastify = makeFastify(redis, elastic);
+
+        const result = await getCachedLastIndexedBlocks(fastify);
+
+        expect(result.cache).toBe(true);
+        expect(result.indexedBlocks).toEqual([2000, 1980]);
+        // the whole point: ES is spared under repeated polling
+        expect(elastic.calls.search).toBe(0);
+        expect(redis.calls.set).toBe(0);
+    });
+
+    it('second call within TTL is a hit served from the first call\'s cached value (one ES query for many probes)', async () => {
+        const redis = makeRedisStub();
+        const elastic = makeElasticStub(500, 480);
+        const fastify = makeFastify(redis, elastic);
+
+        const first = await getCachedLastIndexedBlocks(fastify);
+        const second = await getCachedLastIndexedBlocks(fastify);
+        const third = await getCachedLastIndexedBlocks(fastify);
+
+        expect(first.cache).toBe(false);
+        expect(second.cache).toBe(true);
+        expect(third.cache).toBe(true);
+        // three "probes", a single Elasticsearch query
+        expect(elastic.calls.search).toBe(1);
+        expect(second.indexedBlocks).toEqual(first.indexedBlocks);
+    });
+
+    it('uses a chain-scoped cache key so chains do not share block data', async () => {
+        const redis = makeRedisStub();
+        const elasticA = makeElasticStub(100, 90);
+        const elasticB = makeElasticStub(200, 190);
+
+        const a = await getCachedLastIndexedBlocks(makeFastify(redis, elasticA, 'chainA'));
+        const b = await getCachedLastIndexedBlocks(makeFastify(redis, elasticB, 'chainB'));
+
+        expect(a.indexedBlocks[0]).toBe(100);
+        expect(b.indexedBlocks[0]).toBe(200);
+        expect(redis.store['chainA::last_indexed_blocks']).toBeDefined();
+        expect(redis.store['chainB::last_indexed_blocks']).toBeDefined();
+    });
+});


### PR DESCRIPTION
### Problem

`/v2/health` runs `getLastIndexedBlockWithTotalBlocks` — an Elasticsearch aggregation — on **every** request. It is the one uncached phase in `checkElastic`; the sibling phases (`cluster_health`, `first_indexed_block`/`::fib`, `ship_status`) are all Redis-cached.

Under aggressive health polling — e.g. a load-balancer probe retry-storm — this uncached aggregation saturates the Elasticsearch search pool and can drive the cluster to 100% CPU, while every cached phase is spared.

### Fix

Extract the lookup into `getCachedLastIndexedBlocks()` with a short-TTL (**3s**) Redis cache, mirroring the file's existing cache pattern (chain-scoped key `${chain}::last_indexed_blocks`, same `fastify.redis` get/set). Concurrent probes within the window share a single ES query.

Staleness is bounded to ~3s (~6 chain blocks at 500ms), which is immaterial for a health probe. The per-phase `cache` flag and the response `cached` flag reflect hit/miss. The 3s TTL is a deliberate constant — the sibling caches deliberately range from unbounded (`::fib`) to 30min (`::es_status`), and this value is chosen to absorb polling bursts while keeping the block figure effectively live.

### Tests

Adds `tests/unit/health-cache.test.ts` (bun):
- cache miss → queries ES once, writes Redis, `cache=false`
- cache hit → serves from Redis, **does not touch ES**, `cache=true`
- three sequential probes → a **single** ES query (the core intent)
- keys are chain-scoped (no cross-chain bleed)

Full unit suite: **138 pass**. `tsc` clean.
